### PR TITLE
Adding support for postgres notifications

### DIFF
--- a/gleam.toml
+++ b/gleam.toml
@@ -19,6 +19,7 @@ gleam_otp = ">= 1.0.0 and < 2.0.0"
 gleam_time = ">= 1.2.0 and < 2.0.0"
 pg_value = ">= 2.0.0 and < 3.0.0"
 db_pool = ">= 1.0.0 and < 2.0.0"
+gleam_deque = ">= 1.0.0 and < 2.0.0"
 
 [dev-dependencies]
 gleeunit = "~> 1.0"

--- a/manifest.toml
+++ b/manifest.toml
@@ -4,6 +4,7 @@
 packages = [
   { name = "db_pool", version = "1.0.0", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_otp", "gleam_stdlib"], otp_app = "db_pool", source = "hex", outer_checksum = "7CA513A7A98D130FAD62FA3B93466703680BB1C095D15F1F8029F7DA7C68FA8F" },
   { name = "gleam_crypto", version = "1.5.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_crypto", source = "hex", outer_checksum = "50774BAFFF1144E7872814C566C5D653D83A3EBF23ACC3156B757A1B6819086E" },
+  { name = "gleam_deque", version = "1.0.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_deque", source = "hex", outer_checksum = "64D77068931338CF0D0CB5D37522C3E3CCA7CB7D6C5BACB41648B519CC0133C7" },
   { name = "gleam_erlang", version = "1.3.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "1124AD3AA21143E5AF0FC5CF3D9529F6DB8CA03E43A55711B60B6B7B3874375C" },
   { name = "gleam_otp", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_stdlib"], otp_app = "gleam_otp", source = "hex", outer_checksum = "BA6A294E295E428EC1562DC1C11EA7530DCB981E8359134BEABC8493B7B2258E" },
   { name = "gleam_stdlib", version = "0.68.1", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "F7FAEBD8EF260664E86A46C8DBA23508D1D11BB3BCC6EE1B89B3BC3E5C83FF1E" },
@@ -16,6 +17,7 @@ packages = [
 [requirements]
 db_pool = { version = ">= 1.0.0 and < 2.0.0" }
 gleam_crypto = { version = ">= 1.5.0 and < 2.0.0" }
+gleam_deque = { version = ">= 1.0.0 and < 2.0.0" }
 gleam_erlang = { version = ">= 1.0.0 and < 2.0.0" }
 gleam_otp = { version = ">= 1.0.0 and < 2.0.0" }
 gleam_stdlib = { version = ">= 0.60.0 and < 2.0.0" }

--- a/src/pgl.gleam
+++ b/src/pgl.gleam
@@ -396,7 +396,9 @@ pub fn new(config: Config) -> Db {
 
   let type_cache =
     type_cache.new()
-    |> type_cache.on_connect(fn() { authenticated_connection(config, sockets) })
+    |> type_cache.on_connect(fn() {
+      authenticated_connection(config, sockets, option.None)
+    })
 
   Db(pool:, sockets:, type_cache:, query_cache:, config:)
 }
@@ -433,7 +435,7 @@ pub fn supervised(db: Db) -> supervision.ChildSpecification(Supervisor) {
 }
 
 fn connect(db: Db) -> Result(Socket, PglError) {
-  authenticated_connection(db.config, db.sockets)
+  authenticated_connection(db.config, db.sockets, option.None)
   |> result.map_error(fn(_) { ConnectionError("Failed to open connection") })
 }
 
@@ -443,13 +445,14 @@ fn disconnect(sock: Socket) -> Result(Nil, PglError) {
 }
 
 // TODO: temporary
-pub fn create_socket(db: Db) -> Result(Socket, Nil) {
-  authenticated_connection(db.config, db.sockets)
+pub fn create_socket(db: Db, timeout: socket.Timeout) -> Result(Socket, Nil) {
+  authenticated_connection(db.config, db.sockets, option.Some(timeout))
 }
 
 fn authenticated_connection(
   config: Config,
   sockets: socket.Factory,
+  set_timeout: option.Option(socket.Timeout),
 ) -> Result(Socket, Nil) {
   let conf =
     protocol.config
@@ -459,8 +462,10 @@ fn authenticated_connection(
     |> protocol.password(config.password)
     |> protocol.database(config.database)
 
-  sockets
-  |> socket.connect
+  case set_timeout {
+    option.None -> sockets |> socket.connect
+    option.Some(timeout) -> sockets |> socket.connect_timeout(timeout)
+  }
   |> result.map_error(fn(_) { Nil })
   |> result.try(fn(sock) {
     protocol.auth(sock, conf)

--- a/src/pgl.gleam
+++ b/src/pgl.gleam
@@ -442,6 +442,7 @@ fn disconnect(sock: Socket) -> Result(Nil, PglError) {
   |> result.map_error(from_internal_error)
 }
 
+// TODO: temporary
 pub fn create_socket(db: Db) -> Result(Socket, Nil) {
   authenticated_connection(db.config, db.sockets)
 }
@@ -645,6 +646,7 @@ pub fn execute(sql: String, on connection: Connection) -> Result(Int, PglError) 
   |> result.map_error(from_internal_error)
 }
 
+// TODO: temporarily pub
 pub fn extended_query(
   sql: String,
   params: List(pg_value.Value),

--- a/src/pgl.gleam
+++ b/src/pgl.gleam
@@ -442,6 +442,10 @@ fn disconnect(sock: Socket) -> Result(Nil, PglError) {
   |> result.map_error(from_internal_error)
 }
 
+pub fn create_socket(db: Db) -> Result(Socket, Nil) {
+  authenticated_connection(db.config, db.sockets)
+}
+
 fn authenticated_connection(
   config: Config,
   sockets: socket.Factory,
@@ -559,7 +563,7 @@ pub fn params(q: Query, params: List(pg_value.Value)) -> Query {
 pub fn query(q: Query, connection: Connection) -> Result(Queried, PglError) {
   use conn, db <- with_single_connection(connection)
 
-  extended_query(q.sql, q.params, conn, db)
+  extended_query(q.sql, q.params, conn, db, option.None)
   |> result.map_error(from_internal_error)
   |> result.try(to_queried(_, db.config.rows_as_dict))
 }
@@ -636,22 +640,30 @@ fn rows_to_dicts(
 pub fn execute(sql: String, on connection: Connection) -> Result(Int, PglError) {
   use conn, db <- with_single_connection(connection)
 
-  extended_query(sql, [], conn, db)
+  extended_query(sql, [], conn, db, option.None)
   |> result.map(fn(rows) { rows.count })
   |> result.map_error(from_internal_error)
 }
 
-fn extended_query(
+pub fn extended_query(
   sql: String,
   params: List(pg_value.Value),
   conn: conn.Conn,
   db: Db,
+  handle_notification: option.Option(protocol.HandleNotificationResponse),
 ) -> Result(protocol.Extended(pg_value.Value), internal.InternalError) {
   let message =
     encode_from_cache(sql, params, db)
     |> result.lazy_unwrap(fn() { encode.uncached(sql, params) })
 
-  extended(db)
+  let query = extended(db)
+
+  let query = case handle_notification {
+    option.Some(handler) -> query |> protocol.on_notification(handler)
+    option.None -> query
+  }
+
+  query
   |> protocol.process(message, conn.sock)
 }
 

--- a/src/pgl/internal.gleam
+++ b/src/pgl/internal.gleam
@@ -42,7 +42,7 @@ pub type Message {
   FunctionCallResponse
   NoData
   NoticeResponse(fields: Dict(BitArray, String))
-  NotificationResponse(proc_id: Int, channel: BitArray, payload: BitArray)
+  NotificationResponse(proc_id: Int, channel: String, payload: String)
   ParameterDescription(count: Int, data_types: List(Int))
   ParameterStatus(name: String, value: String)
   ParseComplete

--- a/src/pgl/internal/decode.gleam
+++ b/src/pgl/internal/decode.gleam
@@ -14,6 +14,7 @@ pub fn message(
     <<"1":utf8>> -> parse_complete(payload)
     <<"2":utf8>> -> bind_complete(payload)
     <<"3":utf8>> -> close_complete(payload)
+    <<"A":utf8>> -> notification_response(payload)
     <<"C":utf8>> -> command_complete(payload)
     <<"D":utf8>> -> data_row(payload)
     <<"E":utf8>> -> error_response(payload)
@@ -179,6 +180,41 @@ fn parameter_status(
       }
     }
   })
+}
+
+fn notification_response(
+  payload: BitArray,
+) -> Result(internal.Message, internal.InternalError) {
+  case payload {
+    <<proc_id:int-size(32), rest:bytes>> ->
+      bit_array.to_string(rest)
+      |> result.map_error(fn(_) {
+        internal.DecodingError
+        |> internal.ProtocolError("Unexpected payload for NotificationResponse")
+      })
+      |> result.try(fn(str) {
+        case string.split(str, on: "\u{0000}") {
+          [channel, payload, _] ->
+            Ok(internal.NotificationResponse(
+              proc_id: proc_id,
+              channel:,
+              payload:,
+            ))
+          _ ->
+            internal.DecodingError
+            |> internal.ProtocolError(
+              message: "Unexpected payload for NotificationResponse",
+            )
+            |> Error
+        }
+      })
+    _ ->
+      internal.DecodingError
+      |> internal.ProtocolError(
+        message: "Unexpected payload for NotificationResponse",
+      )
+      |> Error
+  }
 }
 
 fn authentication(

--- a/src/pgl/internal/protocol.gleam
+++ b/src/pgl/internal/protocol.gleam
@@ -317,11 +317,15 @@ pub type HandleParamDescription(v) =
 pub type HandleDecodeRow =
   fn(Row, List(Int)) -> Result(List(Dynamic), internal.InternalError)
 
+pub type HandleNotificationResponse =
+  fn(Int, String, String) -> Nil
+
 pub type Extended(v) {
   Extended(
     needs_sync: Bool,
     handle_decode_row: HandleDecodeRow,
     handle_param_description: HandleParamDescription(v),
+    handle_notification_response: HandleNotificationResponse,
     descriptions: List(internal.RowDescriptionField),
     fields: List(String),
     values: List(List(Dynamic)),
@@ -336,6 +340,7 @@ pub fn extended() -> Extended(v) {
     handle_param_description: fn(_, _, _) {
       panic as "Extended flow not configured"
     },
+    handle_notification_response: fn(_, _, _) { Nil },
     descriptions: [],
     fields: [],
     values: [],
@@ -355,6 +360,13 @@ pub fn on_decode_row(
   handle_decode_row: HandleDecodeRow,
 ) -> Extended(v) {
   Extended(..ext, handle_decode_row:)
+}
+
+pub fn on_notification(
+  ext: Extended(v),
+  handle_notification_response: HandleNotificationResponse,
+) -> Extended(v) {
+  Extended(..ext, handle_notification_response:)
 }
 
 pub fn process(
@@ -496,6 +508,7 @@ fn do_pipeline(
           needs_sync: ext.needs_sync,
           handle_decode_row: ext.handle_decode_row,
           handle_param_description: ext.handle_param_description,
+          handle_notification_response: ext.handle_notification_response,
           descriptions: [],
           fields: [],
           values: [],
@@ -516,8 +529,10 @@ fn do_pipeline(
     }
     internal.NoData -> do_pipeline(pl, ext, queries, sock)
     internal.NoticeResponse(_) -> do_pipeline(pl, ext, queries, sock)
-    internal.NotificationResponse(_, _, _) ->
+    internal.NotificationResponse(proc_id, channel, payload) -> {
+      ext.handle_notification_response(proc_id, channel, payload)
       do_pipeline(pl, ext, queries, sock)
+    }
     internal.ParameterDescription(_, data_types:) ->
       handle_parameter_description(pl, queries, ext, data_types, sock)
     internal.ParseComplete -> do_pipeline(pl, ext, queries, sock)

--- a/src/pgl/internal/protocol.gleam
+++ b/src/pgl/internal/protocol.gleam
@@ -418,7 +418,7 @@ fn handle_data_row(
   Extended(..rows, values:)
 }
 
-fn receive_message(
+pub fn receive_message(
   sock: Socket,
 ) -> Result(internal.Message, internal.InternalError) {
   use data <- result.try(socket.receive(sock, internal.header_size))

--- a/src/pgl/internal/socket.gleam
+++ b/src/pgl/internal/socket.gleam
@@ -247,8 +247,10 @@ fn handle_message(
       actor.continue(sock)
     }
     Receive(client:, receive:, length:, timeout:) -> {
-      receive(sock, length, timeout)
-      |> actor.send(client, _)
+      process.spawn(fn() {
+        receive(sock, length, timeout)
+        |> actor.send(client, _)
+      })
 
       actor.continue(sock)
     }

--- a/src/pgl/internal/socket.gleam
+++ b/src/pgl/internal/socket.gleam
@@ -88,13 +88,7 @@ pub fn port(builder: Builder, port: Int) -> Builder {
   Builder(..builder, port:)
 }
 
-pub fn timeout(builder: Builder, timeout: Int) -> Builder {
-  Builder(..builder, timeout: Timeout(timeout))
-}
-
-// TODO: fix this
-// I just want to test by code
-pub fn timeout_2(builder: Builder, timeout: Timeout) -> Builder {
+pub fn timeout(builder: Builder, timeout: Timeout) -> Builder {
   Builder(..builder, timeout: timeout)
 }
 
@@ -154,7 +148,7 @@ pub fn connect_timeout(
   factory: Factory,
   new_timeout: Timeout,
 ) -> Result(Socket, actor.StartError) {
-  Factory(..factory, builder: factory.builder |> timeout_2(new_timeout))
+  Factory(..factory, builder: factory.builder |> timeout(new_timeout))
   |> connect
 }
 

--- a/src/pgl/internal/socket.gleam
+++ b/src/pgl/internal/socket.gleam
@@ -16,12 +16,17 @@ pub opaque type InternalSocket {
   Ssl(SslSocket)
 }
 
+pub type Timeout {
+  Timeout(Int)
+  Infinite
+}
+
 pub opaque type Builder {
   Builder(
     host: String,
     port: Int,
     ipv6: Bool,
-    timeout: Int,
+    timeout: Timeout,
     send: Sender,
     receive: Receiver,
     shutdown: Disconnector,
@@ -32,7 +37,7 @@ pub opaque type Socket {
   Socket(
     subject: Subject(Msg),
     host: String,
-    timeout: Int,
+    timeout: Timeout,
     parameters: Dict(String, String),
     send: Sender,
     receive: Receiver,
@@ -55,7 +60,7 @@ pub opaque type Msg {
     client: Subject(Result(BitArray, internal.PosixError)),
     receive: Receiver,
     length: Int,
-    timeout: Int,
+    timeout: Timeout,
   )
   Shutdown(
     client: Subject(Result(Nil, internal.PosixError)),
@@ -68,7 +73,7 @@ pub fn new() -> Builder {
     host: internal.default_host,
     port: internal.default_port,
     ipv6: False,
-    timeout: 1000,
+    timeout: Timeout(1000),
     send: socket_send,
     receive: socket_receive,
     shutdown: socket_shutdown,
@@ -84,7 +89,13 @@ pub fn port(builder: Builder, port: Int) -> Builder {
 }
 
 pub fn timeout(builder: Builder, timeout: Int) -> Builder {
-  Builder(..builder, timeout:)
+  Builder(..builder, timeout: Timeout(timeout))
+}
+
+// TODO: fix this
+// I just want to test by code
+pub fn timeout_2(builder: Builder, timeout: Timeout) -> Builder {
+  Builder(..builder, timeout: timeout)
 }
 
 pub fn ipv6(builder: Builder, ipv6: Bool) -> Builder {
@@ -95,7 +106,7 @@ pub type Sender =
   fn(InternalSocket, BitArray) -> Result(Nil, internal.PosixError)
 
 pub type Receiver =
-  fn(InternalSocket, Int, Int) -> Result(BitArray, internal.PosixError)
+  fn(InternalSocket, Int, Timeout) -> Result(BitArray, internal.PosixError)
 
 pub type Disconnector =
   fn(InternalSocket) -> Result(Nil, internal.PosixError)
@@ -137,6 +148,14 @@ pub fn connect(factory: Factory) -> Result(Socket, actor.StartError) {
   factory.get_by_name(factory.name)
   |> factory.start_child(factory.builder)
   |> result.map(fn(started) { started.data })
+}
+
+pub fn connect_timeout(
+  factory: Factory,
+  new_timeout: Timeout,
+) -> Result(Socket, actor.StartError) {
+  Factory(..factory, builder: factory.builder |> timeout_2(new_timeout))
+  |> connect
 }
 
 pub fn supervised(
@@ -201,12 +220,11 @@ pub fn receive(
   conn: Socket,
   length: Int,
 ) -> Result(BitArray, internal.InternalError) {
-  actor.call(conn.subject, conn.timeout, Receive(
-    _,
-    conn.receive,
-    length,
-    conn.timeout,
-  ))
+  let call = case conn.timeout {
+    Timeout(t) -> fn(subj, msg) { actor.call(subj, t, msg) }
+    Infinite -> process.call_forever
+  }
+  call(conn.subject, Receive(_, conn.receive, length, conn.timeout))
   |> result.map_error(fn(code) {
     internal.SocketError(code:, message: "Failed to receive")
   })
@@ -308,10 +326,14 @@ fn socket_send(
 fn socket_receive(
   socket: InternalSocket,
   length: Int,
-  timeout: Int,
+  timeout: Timeout,
 ) -> Result(BitArray, internal.PosixError) {
   case socket {
-    Tcp(sock) -> tcp_receive(sock, length, timeout)
+    Tcp(sock) ->
+      case timeout {
+        Timeout(t) -> tcp_receive(sock, length, t)
+        Infinite -> tcp_receive_infinity(sock, length)
+      }
     Ssl(sock) -> ssl_receive(sock, length)
   }
 }
@@ -337,6 +359,12 @@ fn tcp_receive(
   socket: TcpSocket,
   read_bytes_num: Int,
   timeout_milliseconds timeout: Int,
+) -> Result(BitArray, internal.PosixError)
+
+@external(erlang, "pgl_ffi", "gen_tcp_recv_infinity")
+fn tcp_receive_infinity(
+  socket: TcpSocket,
+  read_bytes_num: Int,
 ) -> Result(BitArray, internal.PosixError)
 
 @external(erlang, "pgl_ffi", "gen_tcp_send")

--- a/src/pgl/notifications.gleam
+++ b/src/pgl/notifications.gleam
@@ -205,24 +205,16 @@ fn handle_manager_message(
 
               case channel_listeners {
                 Error(Nil) ->
-                  case stop_reading(state.sock) {
-                    Ok(Nil) -> {
-                      actor.continue(
-                        NotificationManagerState(
-                          ..state,
-                          inner_state: ManagerSubscribing(channel),
-                          listeners: dict.insert(state.listeners, channel, [
-                            #(monitor, receiver),
-                          ]),
-                        ),
-                      )
-                    }
-                    Error(error) ->
-                      actor.stop_abnormal(
-                        "error while writing sync to socket "
-                        <> string.inspect(error),
-                      )
-                  }
+                  stop_reading(
+                    NotificationManagerState(
+                      ..state,
+                      inner_state: ManagerSubscribing(channel),
+                      listeners: dict.insert(state.listeners, channel, [
+                        #(monitor, receiver),
+                      ]),
+                    ),
+                    state.sock,
+                  )
                 Ok(channel_listeners) ->
                   actor.continue(
                     NotificationManagerState(
@@ -268,19 +260,15 @@ fn handle_manager_message(
 
               case channel_listeners {
                 // We need to unsubscribe from this channel
-                [_] -> {
-                  case stop_reading(state.sock) {
-                    Ok(Nil) -> {
-                      actor.continue(NotificationManagerState(..state, listeners: dict.delete(state.listeners, channel), inner_state: ManagerUnsubscribing(channel)))
-                    }
-                    Error(error) -> {
-                      actor.stop_abnormal(
-                        "error while writing sync to socket "
-                        <> string.inspect(error),
-                      )
-                    }
-                  }
-                }
+                [_] ->
+                  stop_reading(
+                    NotificationManagerState(
+                      ..state,
+                      listeners: dict.delete(state.listeners, channel),
+                      inner_state: ManagerUnsubscribing(channel),
+                    ),
+                    state.sock,
+                  )
                 _ -> {
                   let channel_listeners =
                     list.filter(channel_listeners, fn(channel_listener) {
@@ -319,8 +307,20 @@ fn requeue_message(
 
 // The reader process stops reading, when the servers sends the
 // `ReadyForQuery` response due to our `Sync` command.
-fn stop_reading(sock: socket.Socket) -> Result(Nil, internal.InternalError) {
-  socket.send(sock, encode.sync()) |> result.replace(Nil)
+fn stop_reading(
+  new_state: ManagerState,
+  sock: socket.Socket,
+) -> actor.Next(ManagerState, ManagerMessage) {
+  case socket.send(sock, encode.sync()) |> result.replace(Nil) {
+    Ok(Nil) -> {
+      actor.continue(new_state)
+    }
+    Error(error) -> {
+      actor.stop_abnormal(
+        "error while writing sync to socket " <> string.inspect(error),
+      )
+    }
+  }
 }
 
 fn subscribe(

--- a/src/pgl/notifications.gleam
+++ b/src/pgl/notifications.gleam
@@ -125,7 +125,11 @@ type ManagerMessage {
 
 type ManagerSubscribingState {
   ManagerIdle
-  ManagerSubscribing(channel: String)
+  ManagerSubscribing(
+    channel: String,
+    reply: process.Subject(Result(NotificationHandle, Nil)),
+    handle: NotificationHandle,
+  )
   ManagerUnsubscribing(channel: String)
 }
 
@@ -215,9 +219,10 @@ fn handle_manager_message(
     }
     ReceivedNotification(StoppedReading) ->
       case state.inner_state {
-        ManagerSubscribing(channel) -> {
+        ManagerSubscribing(channel, reply, handle) -> {
           case subscribe(state, channel) {
             Ok(Nil) -> {
+              process.send(reply, Ok(handle))
               start_reading(state.reader, state.sock, state.reader_receiver)
               actor.continue(
                 NotificationManagerState(..state, inner_state: ManagerIdle),
@@ -266,21 +271,23 @@ fn handle_manager_message(
             Ok(monitor) -> {
               let channel_listeners = dict.get(state.listeners, channel)
 
-              process.send(reply, Ok(NotificationHandle(monitor)))
 
               case channel_listeners {
                 Error(Nil) ->
                   stop_reading(
                     NotificationManagerState(
                       ..state,
-                      inner_state: ManagerSubscribing(channel),
+                      inner_state: ManagerSubscribing(channel, reply, NotificationHandle(monitor)),
                       listeners: dict.insert(state.listeners, channel, [
                         #(monitor, receiver),
                       ]),
                     ),
                     state.sock,
                   )
-                Ok(channel_listeners) ->
+                Ok(channel_listeners) -> {
+                  // Since we're already subscribed we'll immediately get any
+                  // notifications.
+                  process.send(reply, Ok(NotificationHandle(monitor)))
                   actor.continue(
                     NotificationManagerState(
                       ..state,
@@ -290,6 +297,7 @@ fn handle_manager_message(
                       ]),
                     ),
                   )
+                }
               }
             }
             Error(Nil) -> {

--- a/src/pgl/notifications.gleam
+++ b/src/pgl/notifications.gleam
@@ -24,14 +24,29 @@ pub opaque type Notifications {
 
 pub fn start(
   notifications: Notifications,
+  db: pgl.Db,
 ) -> actor.StartResult(static_supervisor.Supervisor) {
+  let reader_subject = process.named_subject(notifications.reader)
+
   static_supervisor.new(static_supervisor.OneForAll)
   |> static_supervisor.add(supervised_reader(notifications.reader))
+  |> static_supervisor.add(supervised_manager(
+    notifications.manager,
+    db,
+    reader_subject,
+  ))
   |> static_supervisor.start
 }
 
 pub fn manager_pid(notifications: Notifications) -> option.Option(process.Pid) {
   process.named(notifications.manager) |> option.from_result
+}
+
+pub fn supervised(
+  notifications: Notifications,
+  db: pgl.Db,
+) -> supervision.ChildSpecification(static_supervisor.Supervisor) {
+  supervision.supervisor(fn() { start(notifications, db) })
 }
 
 pub opaque type NotificationHandle {
@@ -109,6 +124,16 @@ fn start_manager(
   |> actor.named(name)
   |> actor.on_message(handle_manager_message)
   |> actor.start
+}
+
+fn supervised_manager(
+  name: process.Name(ManagerMessage),
+  db: pgl.Db,
+  reader: process.Subject(ReaderMessage),
+) -> supervision.ChildSpecification(Nil) {
+  supervision.worker(fn() { start_manager(name, db, reader) })
+  |> supervision.timeout(1000)
+  |> supervision.restart(supervision.Permanent)
 }
 
 fn handle_manager_message(
@@ -381,7 +406,7 @@ fn supervised_reader(
 ) -> supervision.ChildSpecification(Nil) {
   supervision.worker(fn() { start_reader(name) })
   |> supervision.timeout(1000)
-  |> supervision.restart(supervision.Transient)
+  |> supervision.restart(supervision.Permanent)
   |> supervision.map_data(fn(_) { Nil })
 }
 

--- a/src/pgl/notifications.gleam
+++ b/src/pgl/notifications.gleam
@@ -25,8 +25,8 @@
 // Notes:
 // - If the manager crashes, we lose all state of what processes have subscribed to
 // which channels and which channels we're even subscribed to.
-// - For this reason, both processes are marked as `significant` causing the 
-// supervisor to crash when they crash. A crash leaves all listening processes
+// - For this reason, the supervisor has a max restart intensity of 0 causing the
+// supervisor to crash when either process crashes. A crash leaves all listening processes
 // in a broken state, since they believe they're still subscribed, but they're not,
 // they should crash by either linking to the manager process using `manager_pid`
 // or being in a supervisor which gets restarted when the notification supervisor restarts.

--- a/src/pgl/notifications.gleam
+++ b/src/pgl/notifications.gleam
@@ -185,8 +185,7 @@ fn handle_manager_message(
           }
         }
         _ -> {
-          process.send(state.self_subject, message)
-          actor.continue(state)
+          requeue_message(state, message)
         }
       }
     Unlisten(handle) ->
@@ -234,11 +233,15 @@ fn handle_manager_message(
           }
         }
         _ -> {
-          process.send(state.self_subject, message)
-          actor.continue(state)
+          requeue_message(state, message)
         }
       }
   }
+}
+
+fn requeue_message(state: ManagerState, message: ManagerMessage) -> actor.Next(ManagerState, ManagerMessage) {
+  process.send(state.self_subject, message)
+  actor.continue(state)
 }
 
 // The reader process stops reading, when the servers sends the

--- a/src/pgl/notifications.gleam
+++ b/src/pgl/notifications.gleam
@@ -216,12 +216,13 @@ fn handle_manager_message(
     ReceivedNotification(StoppedReading) ->
       case state.inner_state {
         ManagerSubscribing(channel) -> {
-          start_reading(state.reader, state.sock, state.reader_receiver)
           case subscribe(state, channel) {
-            Ok(Nil) ->
+            Ok(Nil) -> {
+              start_reading(state.reader, state.sock, state.reader_receiver)
               actor.continue(
                 NotificationManagerState(..state, inner_state: ManagerIdle),
               )
+            }
             Error(error) ->
               actor.stop_abnormal(
                 "failure to subscribe to channel "
@@ -232,12 +233,13 @@ fn handle_manager_message(
           }
         }
         ManagerUnsubscribing(channel) -> {
-          start_reading(state.reader, state.sock, state.reader_receiver)
           case unsubscribe(state, channel) {
-            Ok(Nil) ->
+            Ok(Nil) -> {
+              start_reading(state.reader, state.sock, state.reader_receiver)
               actor.continue(
                 NotificationManagerState(..state, inner_state: ManagerIdle),
               )
+            }
             Error(error) ->
               actor.stop_abnormal(
                 "failure to unsubscribe from channel "

--- a/src/pgl/notifications.gleam
+++ b/src/pgl/notifications.gleam
@@ -127,6 +127,20 @@ fn handle_manager_message(
     }
     ReceivedNotification(StoppedReading) ->
       case state.inner_state {
+        ManagerSubscribing(channel) -> {
+          start_reading(state.reader, state.sock, state.reader_receiver)
+          case subscribe(state, channel) {
+            Ok(Nil) -> actor.continue(NotificationManagerState(..state, inner_state: ManagerIdle))
+            Error(error) -> actor.stop_abnormal("failure to subscribe to channel " <> channel <> " " <> string.inspect(error))
+          }
+        }
+        ManagerUnsubscribing(channel) -> {
+          start_reading(state.reader, state.sock, state.reader_receiver)
+          case unsubscribe(state, channel) {
+            Ok(Nil) -> actor.continue(NotificationManagerState(..state, inner_state: ManagerIdle))
+            Error(error) -> actor.stop_abnormal("failure to unsubscribe from channel " <> channel <> " " <> string.inspect(error))
+          }
+        }
         // StoppedReading should only be received, if we issued a sync before.
         ManagerIdle ->
           actor.stop_abnormal(
@@ -309,6 +323,10 @@ type ReaderNotification {
 
 type ReaderMessage {
   Read(socket: socket.Socket, receiver: process.Subject(ReaderNotification))
+}
+
+fn start_reading(reader: process.Subject(ReaderMessage), socket: socket.Socket, receiver: process.Subject(ReaderNotification)) {
+  process.send(reader, Read(socket:, receiver:))
 }
 
 fn start_reader(

--- a/src/pgl/notifications.gleam
+++ b/src/pgl/notifications.gleam
@@ -7,7 +7,6 @@ import gleam/otp/static_supervisor
 import gleam/otp/supervision
 import gleam/result
 import gleam/string
-import gleam/time/timestamp
 import pg_value
 import pgl
 import pgl/internal
@@ -150,7 +149,6 @@ fn handle_manager_message(
                 Error(Nil) ->
                   case stop_reading(state.sock) {
                     Ok(Nil) -> {
-
                       actor.continue(
                         NotificationManagerState(
                           ..state,
@@ -160,7 +158,7 @@ fn handle_manager_message(
                           ]),
                         ),
                       )
-}
+                    }
                     Error(error) ->
                       actor.stop_abnormal(
                         "error while writing sync to socket "

--- a/src/pgl/notifications.gleam
+++ b/src/pgl/notifications.gleam
@@ -1,5 +1,35 @@
 //// PostgreSQL notification client
 
+// notification system
+// This notification system is very loosely based on the `pgo_notifications` module.
+// Requirements while building:
+// 1. Use paramaterised queries for LISTEN and UNLISTEN commands.
+// 2. Reuse existing code for sending extended queries to database.
+// This leads to a problem:
+// - We need direct access to the socket for sending these subscribe messages.
+// - A process needs to be constantly reading from this socket in order to receive
+// notifications.
+// - We don't have a good way to interrupt a read in gleam.
+// - My initial idea, having two processes reading and writing messages on the the socket,
+// then communicating with a manager process doesn't work, as it violates requirement 2.
+// To solve this we have the following architecture:
+// - One manager process which keeps track of which channels we're subscribed to and
+// who needs to be notified on the arrival of a notification.
+// - One reader process which constantly reads on the socket and sends incoming notifications
+// to the manager process, which then forwards them on.
+// - When the manager needs exclusive access to the socket for sending LISTEN and UNLISTEN
+// commands, it writes a `Sync` message to the socket. This results in a `ReadyForQuery` message
+// arriving at the reader, which uses this as a signal to quit reading.
+//
+// Notes:
+// - If the manager crashes, we lose all state of what processes have subscribed to
+// which channels and which channels we're even subscribed to.
+// - For this reason, both processes are marked as `significant` causing the 
+// supervisor to crash when they crash. A crash leaves all listening processes
+// in a broken state, since they believe they're still subscribed, but they're not,
+// they should crash by either linking to the manager process using `manager_pid`
+// or being in a supervisor which gets restarted when the notification supervisor restarts.
+
 import gleam/dict
 import gleam/erlang/process
 import gleam/list
@@ -35,6 +65,7 @@ pub fn new(db: pgl.Db) -> Notifications {
   )
 }
 
+
 pub fn start(
   notifications: Notifications,
 ) -> actor.StartResult(static_supervisor.Supervisor) {
@@ -47,6 +78,7 @@ pub fn start(
     notifications.db,
     reader_subject,
   ))
+  |> static_supervisor.auto_shutdown(static_supervisor.AnySignificant)
   |> static_supervisor.start
 }
 
@@ -163,6 +195,7 @@ fn supervised_manager(
   supervision.worker(fn() { start_manager(name, db, reader) })
   |> supervision.timeout(1000)
   |> supervision.restart(supervision.Permanent)
+  |> supervision.significant(True)
 }
 
 fn handle_manager_message(
@@ -437,6 +470,7 @@ fn supervised_reader(
   |> supervision.timeout(1000)
   |> supervision.restart(supervision.Permanent)
   |> supervision.map_data(fn(_) { Nil })
+  |> supervision.significant(True)
 }
 
 fn handle_reader_message(

--- a/src/pgl/notifications.gleam
+++ b/src/pgl/notifications.gleam
@@ -191,7 +191,48 @@ fn handle_manager_message(
       }
     Unlisten(handle) ->
       case state.inner_state {
-        ManagerIdle -> todo
+        ManagerIdle -> {
+          process.demonitor_process(handle.monitor)
+
+          case
+            dict.fold(state.listeners, option.None, fn(acc, channel, listeners) {
+              case acc {
+                option.Some(_) -> acc
+                option.None ->
+                  case list.any(listeners, fn(v) { v.0 == handle.monitor }) {
+                    True -> option.Some(channel)
+                    False -> acc
+                  }
+              }
+            })
+          {
+            option.Some(channel) -> {
+              let assert Ok(channel_listeners) = dict.get(state.listeners, channel)
+
+              case channel_listeners {
+                // We need to unsubscribe from this channel
+                [_] -> {
+                  case stop_reading(state.sock) {
+                    Ok(Nil) -> {
+                      actor.continue(NotificationManagerState(..state, listeners: dict.delete(state.listeners, channel), inner_state: ManagerUnsubscribing(channel)))
+                    }
+                    Error(error) -> {
+                      actor.stop_abnormal(
+                        "error while writing sync to socket "
+                        <> string.inspect(error),
+                      )
+                    }
+                  }
+                }
+                _ -> {
+                  let channel_listeners = list.filter(channel_listeners, fn(channel_listener) { channel_listener.0 == handle.monitor })
+                  actor.continue(NotificationManagerState(..state, listeners: dict.insert(state.listeners, channel, channel_listeners)))
+                }
+              }
+            }
+            option.None -> actor.continue(state)
+          }
+        }
         _ -> {
           process.send(state.self_subject, message)
           actor.continue(state)

--- a/src/pgl/notifications.gleam
+++ b/src/pgl/notifications.gleam
@@ -31,7 +31,6 @@
 // they should crash by either linking to the manager process using `manager_pid`
 // or being in a supervisor which gets restarted when the notification supervisor restarts.
 
-import pg_value
 import gleam/dict
 import gleam/erlang/process
 import gleam/list
@@ -407,8 +406,8 @@ fn subscribe(
 ) -> Result(Nil, internal.InternalError) {
   let connection = conn.new(state.sock, process.self())
   pgl.extended_query(
-    "LISTEN \"$1\"",
-    [pg_value.text(channel)],
+    "LISTEN " <> escape_channel(channel),
+    [],
     connection,
     state.db,
     // Forwarding any notifications received during the query
@@ -431,8 +430,8 @@ fn unsubscribe(
 ) -> Result(Nil, internal.InternalError) {
   let connection = conn.new(state.sock, process.self())
   pgl.extended_query(
-    "UNLISTEN \"$1\"",
-    [pg_value.text(channel)],
+    "UNLISTEN " <> escape_channel(channel),
+    [],
     connection,
     state.db,
     // Forwarding any notifications received during the query

--- a/src/pgl/notifications.gleam
+++ b/src/pgl/notifications.gleam
@@ -130,15 +130,33 @@ fn handle_manager_message(
         ManagerSubscribing(channel) -> {
           start_reading(state.reader, state.sock, state.reader_receiver)
           case subscribe(state, channel) {
-            Ok(Nil) -> actor.continue(NotificationManagerState(..state, inner_state: ManagerIdle))
-            Error(error) -> actor.stop_abnormal("failure to subscribe to channel " <> channel <> " " <> string.inspect(error))
+            Ok(Nil) ->
+              actor.continue(
+                NotificationManagerState(..state, inner_state: ManagerIdle),
+              )
+            Error(error) ->
+              actor.stop_abnormal(
+                "failure to subscribe to channel "
+                <> channel
+                <> " "
+                <> string.inspect(error),
+              )
           }
         }
         ManagerUnsubscribing(channel) -> {
           start_reading(state.reader, state.sock, state.reader_receiver)
           case unsubscribe(state, channel) {
-            Ok(Nil) -> actor.continue(NotificationManagerState(..state, inner_state: ManagerIdle))
-            Error(error) -> actor.stop_abnormal("failure to unsubscribe from channel " <> channel <> " " <> string.inspect(error))
+            Ok(Nil) ->
+              actor.continue(
+                NotificationManagerState(..state, inner_state: ManagerIdle),
+              )
+            Error(error) ->
+              actor.stop_abnormal(
+                "failure to unsubscribe from channel "
+                <> channel
+                <> " "
+                <> string.inspect(error),
+              )
           }
         }
         // StoppedReading should only be received, if we issued a sync before.
@@ -220,7 +238,8 @@ fn handle_manager_message(
             })
           {
             option.Some(channel) -> {
-              let assert Ok(channel_listeners) = dict.get(state.listeners, channel)
+              let assert Ok(channel_listeners) =
+                dict.get(state.listeners, channel)
 
               case channel_listeners {
                 // We need to unsubscribe from this channel
@@ -238,8 +257,20 @@ fn handle_manager_message(
                   }
                 }
                 _ -> {
-                  let channel_listeners = list.filter(channel_listeners, fn(channel_listener) { channel_listener.0 != handle.monitor })
-                  actor.continue(NotificationManagerState(..state, listeners: dict.insert(state.listeners, channel, channel_listeners)))
+                  let channel_listeners =
+                    list.filter(channel_listeners, fn(channel_listener) {
+                      channel_listener.0 != handle.monitor
+                    })
+                  actor.continue(
+                    NotificationManagerState(
+                      ..state,
+                      listeners: dict.insert(
+                        state.listeners,
+                        channel,
+                        channel_listeners,
+                      ),
+                    ),
+                  )
                 }
               }
             }
@@ -253,7 +284,10 @@ fn handle_manager_message(
   }
 }
 
-fn requeue_message(state: ManagerState, message: ManagerMessage) -> actor.Next(ManagerState, ManagerMessage) {
+fn requeue_message(
+  state: ManagerState,
+  message: ManagerMessage,
+) -> actor.Next(ManagerState, ManagerMessage) {
   process.send(state.self_subject, message)
   actor.continue(state)
 }
@@ -325,7 +359,11 @@ type ReaderMessage {
   Read(socket: socket.Socket, receiver: process.Subject(ReaderNotification))
 }
 
-fn start_reading(reader: process.Subject(ReaderMessage), socket: socket.Socket, receiver: process.Subject(ReaderNotification)) {
+fn start_reading(
+  reader: process.Subject(ReaderMessage),
+  socket: socket.Socket,
+  receiver: process.Subject(ReaderNotification),
+) {
   process.send(reader, Read(socket:, receiver:))
 }
 

--- a/src/pgl/notifications.gleam
+++ b/src/pgl/notifications.gleam
@@ -38,10 +38,6 @@ pub fn start(
   |> static_supervisor.start
 }
 
-pub fn manager_pid(notifications: Notifications) -> option.Option(process.Pid) {
-  process.named(notifications.manager) |> option.from_result
-}
-
 pub fn supervised(
   notifications: Notifications,
   db: pgl.Db,

--- a/src/pgl/notifications.gleam
+++ b/src/pgl/notifications.gleam
@@ -49,6 +49,24 @@ pub fn supervised(
   supervision.supervisor(fn() { start(notifications, db) })
 }
 
+pub fn listen(
+  notifications: Notifications,
+  channel: String,
+  receiver: process.Subject(Notification),
+) -> NotificationHandle {
+  let manager = process.named_subject(notifications.manager)
+
+  let assert Ok(handle) =
+    actor.call(manager, 1000, fn(reply) { Listen(reply:, receiver:, channel:) })
+
+  handle
+}
+
+pub fn unlisten(notifications: Notifications, handle: NotificationHandle) {
+  let manager = process.named_subject(notifications.manager)
+  actor.send(manager, Unlisten(handle))
+}
+
 pub opaque type NotificationHandle {
   NotificationHandle(monitor: process.Monitor)
 }

--- a/src/pgl/notifications.gleam
+++ b/src/pgl/notifications.gleam
@@ -78,7 +78,7 @@ pub fn start(
     notifications.db,
     reader_subject,
   ))
-  |> static_supervisor.auto_shutdown(static_supervisor.AnySignificant)
+  |> static_supervisor.restart_tolerance(0, 1)
   |> static_supervisor.start
 }
 
@@ -194,8 +194,7 @@ fn supervised_manager(
 ) -> supervision.ChildSpecification(Nil) {
   supervision.worker(fn() { start_manager(name, db, reader) })
   |> supervision.timeout(1000)
-  |> supervision.restart(supervision.Permanent)
-  |> supervision.significant(True)
+  |> supervision.restart(supervision.Transient)
 }
 
 fn handle_manager_message(
@@ -468,9 +467,8 @@ fn supervised_reader(
 ) -> supervision.ChildSpecification(Nil) {
   supervision.worker(fn() { start_reader(name) })
   |> supervision.timeout(1000)
-  |> supervision.restart(supervision.Permanent)
+  |> supervision.restart(supervision.Transient)
   |> supervision.map_data(fn(_) { Nil })
-  |> supervision.significant(True)
 }
 
 fn handle_reader_message(

--- a/src/pgl/notifications.gleam
+++ b/src/pgl/notifications.gleam
@@ -31,6 +31,7 @@
 // they should crash by either linking to the manager process using `manager_pid`
 // or being in a supervisor which gets restarted when the notification supervisor restarts.
 
+import gleam/deque
 import gleam/dict
 import gleam/erlang/process
 import gleam/list
@@ -136,6 +137,7 @@ type ManagerSubscribingState {
 type ManagerState {
   NotificationManagerState(
     inner_state: ManagerSubscribingState,
+    postponed: deque.Deque(ManagerMessage),
     db: pgl.Db,
     sock: socket.Socket,
     listeners: dict.Dict(
@@ -177,6 +179,7 @@ fn start_manager(
 
     NotificationManagerState(
       inner_state: ManagerIdle,
+      postponed: deque.new(),
       db:,
       sock:,
       listeners: dict.new(),
@@ -189,7 +192,7 @@ fn start_manager(
     |> Ok
   })
   |> actor.named(name)
-  |> actor.on_message(handle_manager_message)
+  |> actor.on_message(on_manager_message)
   |> actor.start
 }
 
@@ -203,10 +206,51 @@ fn supervised_manager(
   |> supervision.restart(supervision.Transient)
 }
 
-fn handle_manager_message(
+fn on_manager_message(
   state: ManagerState,
   message: ManagerMessage,
 ) -> actor.Next(ManagerState, ManagerMessage) {
+  let start_state_is_idle = state.inner_state == ManagerIdle
+  case handle_manager_message(state, message) {
+    Ok(state) -> {
+      let end_state_is_idle = state.inner_state == ManagerIdle
+      let maybe_postponed_work = { !start_state_is_idle } && end_state_is_idle
+      case maybe_postponed_work {
+        True -> {
+          handle_postponed_work(state)
+        }
+        False -> {
+          actor.continue(state)
+        }
+      }
+    }
+    Error(reason) -> actor.stop_abnormal(reason)
+  }
+}
+
+fn handle_postponed_work(
+  state: ManagerState,
+) -> actor.Next(ManagerState, ManagerMessage) {
+  case deque.pop_back(state.postponed) {
+    Error(Nil) -> actor.continue(state)
+    Ok(#(postponed_message, postponed)) -> {
+      let state = NotificationManagerState(..state, postponed:)
+      case handle_manager_message(state, postponed_message) {
+        Ok(state) ->
+          case state.inner_state {
+            ManagerIdle -> handle_postponed_work(state)
+            _ -> actor.continue(state)
+          }
+        Error(reason) -> actor.stop_abnormal(reason)
+      }
+    }
+  }
+}
+
+fn handle_manager_message(
+  state: ManagerState,
+  message: ManagerMessage,
+) -> Result(ManagerState, String) {
   case message {
     ReceivedNotification(ReaderNotification(notification)) -> {
       let receivers =
@@ -215,7 +259,7 @@ fn handle_manager_message(
         let #(_, receiver) = receiver
         process.send(receiver, notification)
       })
-      actor.continue(state)
+      Ok(state)
     }
     ReceivedNotification(StoppedReading) ->
       case state.inner_state {
@@ -224,12 +268,10 @@ fn handle_manager_message(
             Ok(Nil) -> {
               process.send(reply, Ok(handle))
               start_reading(state.reader, state.sock, state.reader_receiver)
-              actor.continue(
-                NotificationManagerState(..state, inner_state: ManagerIdle),
-              )
+              Ok(NotificationManagerState(..state, inner_state: ManagerIdle))
             }
             Error(error) ->
-              actor.stop_abnormal(
+              Error(
                 "failure to subscribe to channel "
                 <> channel
                 <> " "
@@ -241,12 +283,10 @@ fn handle_manager_message(
           case unsubscribe(state, channel) {
             Ok(Nil) -> {
               start_reading(state.reader, state.sock, state.reader_receiver)
-              actor.continue(
-                NotificationManagerState(..state, inner_state: ManagerIdle),
-              )
+              Ok(NotificationManagerState(..state, inner_state: ManagerIdle))
             }
             Error(error) ->
-              actor.stop_abnormal(
+              Error(
                 "failure to unsubscribe from channel "
                 <> channel
                 <> " "
@@ -256,9 +296,7 @@ fn handle_manager_message(
         }
         // StoppedReading should only be received, if we issued a sync before.
         ManagerIdle ->
-          actor.stop_abnormal(
-            "unexpected message ReceivedNotification(StoppedReading)",
-          )
+          Error("unexpected message ReceivedNotification(StoppedReading)")
       }
     Listen(reply, receiver, channel) ->
       case state.inner_state {
@@ -271,13 +309,16 @@ fn handle_manager_message(
             Ok(monitor) -> {
               let channel_listeners = dict.get(state.listeners, channel)
 
-
               case channel_listeners {
                 Error(Nil) ->
                   stop_reading(
                     NotificationManagerState(
                       ..state,
-                      inner_state: ManagerSubscribing(channel, reply, NotificationHandle(monitor)),
+                      inner_state: ManagerSubscribing(
+                        channel,
+                        reply,
+                        NotificationHandle(monitor),
+                      ),
                       listeners: dict.insert(state.listeners, channel, [
                         #(monitor, receiver),
                       ]),
@@ -288,7 +329,7 @@ fn handle_manager_message(
                   // Since we're already subscribed we'll immediately get any
                   // notifications.
                   process.send(reply, Ok(NotificationHandle(monitor)))
-                  actor.continue(
+                  Ok(
                     NotificationManagerState(
                       ..state,
                       listeners: dict.insert(state.listeners, channel, [
@@ -302,12 +343,12 @@ fn handle_manager_message(
             }
             Error(Nil) -> {
               process.send(reply, Error(Nil))
-              actor.continue(state)
+              Ok(state)
             }
           }
         }
         _ -> {
-          requeue_message(state, message)
+          postpone_message(state, message)
         }
       }
     Unlisten(handle) ->
@@ -347,7 +388,7 @@ fn handle_manager_message(
                     list.filter(channel_listeners, fn(channel_listener) {
                       channel_listener.0 != handle.monitor
                     })
-                  actor.continue(
+                  Ok(
                     NotificationManagerState(
                       ..state,
                       listeners: dict.insert(
@@ -360,22 +401,26 @@ fn handle_manager_message(
                 }
               }
             }
-            option.None -> actor.continue(state)
+            option.None -> Ok(state)
           }
         }
         _ -> {
-          requeue_message(state, message)
+          postpone_message(state, message)
         }
       }
   }
 }
 
-fn requeue_message(
+fn postpone_message(
   state: ManagerState,
   message: ManagerMessage,
-) -> actor.Next(ManagerState, ManagerMessage) {
-  process.send(state.self_subject, message)
-  actor.continue(state)
+) -> Result(ManagerState, String) {
+  Ok(
+    NotificationManagerState(
+      ..state,
+      postponed: deque.push_front(state.postponed, message),
+    ),
+  )
 }
 
 // The reader process stops reading, when the servers sends the
@@ -383,15 +428,13 @@ fn requeue_message(
 fn stop_reading(
   new_state: ManagerState,
   sock: socket.Socket,
-) -> actor.Next(ManagerState, ManagerMessage) {
+) -> Result(ManagerState, String) {
   case socket.send(sock, encode.sync()) |> result.replace(Nil) {
     Ok(Nil) -> {
-      actor.continue(new_state)
+      Ok(new_state)
     }
     Error(error) -> {
-      actor.stop_abnormal(
-        "error while writing sync to socket " <> string.inspect(error),
-      )
+      Error("error while writing sync to socket " <> string.inspect(error))
     }
   }
 }

--- a/src/pgl/notifications.gleam
+++ b/src/pgl/notifications.gleam
@@ -45,7 +45,7 @@ type ManagerMessage {
     receiver: process.Subject(Notification),
     channel: String,
   )
-  Unlisten(handle: NotificationHandle, channel: String)
+  Unlisten(handle: NotificationHandle)
   ReceivedNotification(notification: ReaderNotification)
   ListenerDown(monitor: process.Monitor)
 }
@@ -190,7 +190,7 @@ fn handle_manager_message(
           actor.continue(state)
         }
       }
-    Unlisten(handle:, channel:) ->
+    Unlisten(handle:) ->
       case state.inner_state {
         ManagerIdle -> todo
         _ -> {

--- a/src/pgl/notifications.gleam
+++ b/src/pgl/notifications.gleam
@@ -3,7 +3,8 @@
 // notification system
 // This notification system is very loosely based on the `pgo_notifications` module.
 // Requirements while building:
-// 1. Use paramaterised queries for LISTEN and UNLISTEN commands.
+// 1. ~~Use paramaterised queries for LISTEN and UNLISTEN commands.~~
+//   - so turns out you can't use query parameters for the channel part of a LISTEN statement.
 // 2. Reuse existing code for sending extended queries to database.
 // This leads to a problem:
 // - We need direct access to the socket for sending these subscribe messages.
@@ -39,7 +40,6 @@ import gleam/otp/static_supervisor
 import gleam/otp/supervision
 import gleam/result
 import gleam/string
-import pg_value
 import pgl
 import pgl/internal
 import pgl/internal/conn
@@ -64,7 +64,6 @@ pub fn new(db: pgl.Db) -> Notifications {
     db:,
   )
 }
-
 
 pub fn start(
   notifications: Notifications,
@@ -387,14 +386,18 @@ fn stop_reading(
   }
 }
 
+fn escape_channel(raw_channel: String) -> String {
+  "\"" <> string.replace(raw_channel, "\"", "\\\"") <> "\""
+}
+
 fn subscribe(
   state: ManagerState,
   channel: String,
 ) -> Result(Nil, internal.InternalError) {
   let connection = conn.new(state.sock, process.self())
   pgl.extended_query(
-    "LISTEN $1",
-    [pg_value.text(channel)],
+    "LISTEN " <> escape_channel(channel),
+    [],
     connection,
     state.db,
     // Forwarding any notifications received during the query
@@ -417,8 +420,8 @@ fn unsubscribe(
 ) -> Result(Nil, internal.InternalError) {
   let connection = conn.new(state.sock, process.self())
   pgl.extended_query(
-    "UNLISTEN $1",
-    [pg_value.text(channel)],
+    "UNLISTEN " <> escape_channel(channel),
+    [],
     connection,
     state.db,
     // Forwarding any notifications received during the query

--- a/src/pgl/notifications.gleam
+++ b/src/pgl/notifications.gleam
@@ -170,6 +170,8 @@ fn start_manager(
       |> result.replace_error("unable to create socket"),
     )
 
+    start_reading(reader, sock, reader_receiver)
+
     NotificationManagerState(
       inner_state: ManagerIdle,
       db:,

--- a/src/pgl/notifications.gleam
+++ b/src/pgl/notifications.gleam
@@ -166,7 +166,8 @@ fn start_manager(
       })
 
     use sock <- result.try(
-      pgl.create_socket(db) |> result.replace_error("unable to create socket"),
+      pgl.create_socket(db, socket.Infinite)
+      |> result.replace_error("unable to create socket"),
     )
 
     NotificationManagerState(

--- a/src/pgl/notifications.gleam
+++ b/src/pgl/notifications.gleam
@@ -38,6 +38,10 @@ pub fn start(
   |> static_supervisor.start
 }
 
+pub fn manager_pid(notifications: Notifications) -> option.Option(process.Pid) {
+  process.named(notifications.manager) |> option.from_result
+}
+
 pub fn supervised(
   notifications: Notifications,
   db: pgl.Db,

--- a/src/pgl/notifications.gleam
+++ b/src/pgl/notifications.gleam
@@ -238,7 +238,7 @@ fn handle_manager_message(
                   }
                 }
                 _ -> {
-                  let channel_listeners = list.filter(channel_listeners, fn(channel_listener) { channel_listener.0 == handle.monitor })
+                  let channel_listeners = list.filter(channel_listeners, fn(channel_listener) { channel_listener.0 != handle.monitor })
                   actor.continue(NotificationManagerState(..state, listeners: dict.insert(state.listeners, channel, channel_listeners)))
                 }
               }

--- a/src/pgl/notifications.gleam
+++ b/src/pgl/notifications.gleam
@@ -142,11 +142,11 @@ fn handle_manager_message(
             })
           {
             Ok(monitor) -> {
-              let listeners = dict.get(state.listeners, channel)
+              let channel_listeners = dict.get(state.listeners, channel)
 
               process.send(reply, Ok(NotificationHandle(monitor)))
 
-              case listeners {
+              case channel_listeners {
                 Error(Nil) ->
                   case stop_reading(state.sock) {
                     Ok(Nil) -> {
@@ -166,13 +166,13 @@ fn handle_manager_message(
                         <> string.inspect(error),
                       )
                   }
-                Ok(listeners) ->
+                Ok(channel_listeners) ->
                   actor.continue(
                     NotificationManagerState(
                       ..state,
                       listeners: dict.insert(state.listeners, channel, [
                         #(monitor, receiver),
-                        ..listeners
+                        ..channel_listeners
                       ]),
                     ),
                   )

--- a/src/pgl/notifications.gleam
+++ b/src/pgl/notifications.gleam
@@ -132,7 +132,7 @@ fn handle_manager_message(
             "unexpected message ReceivedNotification(StoppedReading)",
           )
       }
-    Listen(reply:, receiver:, channel:) ->
+    Listen(reply, receiver, channel) ->
       case state.inner_state {
         ManagerIdle -> {
           case
@@ -188,7 +188,7 @@ fn handle_manager_message(
           actor.continue(state)
         }
       }
-    Unlisten(handle:) ->
+    Unlisten(handle) ->
       case state.inner_state {
         ManagerIdle -> todo
         _ -> {
@@ -196,7 +196,7 @@ fn handle_manager_message(
           actor.continue(state)
         }
       }
-    ListenerDown(monitor:) ->
+    ListenerDown(monitor) ->
       case state.inner_state {
         ManagerIdle -> todo
         _ -> {

--- a/src/pgl/notifications.gleam
+++ b/src/pgl/notifications.gleam
@@ -1,0 +1,333 @@
+import gleam/dict
+import gleam/erlang/process
+import gleam/list
+import gleam/option
+import gleam/otp/actor
+import gleam/otp/static_supervisor
+import gleam/otp/supervision
+import gleam/result
+import gleam/string
+import gleam/time/timestamp
+import pg_value
+import pgl
+import pgl/internal
+import pgl/internal/conn
+import pgl/internal/encode
+import pgl/internal/protocol
+import pgl/internal/socket
+
+pub opaque type Notifications {
+  Notifications(
+    manager: process.Name(ManagerMessage),
+    reader: process.Name(ReaderMessage),
+  )
+}
+
+pub fn start(
+  notifications: Notifications,
+) -> actor.StartResult(static_supervisor.Supervisor) {
+  static_supervisor.new(static_supervisor.OneForAll)
+  |> static_supervisor.add(supervised_reader(notifications.reader))
+  |> static_supervisor.start
+}
+
+pub fn manager_pid(notifications: Notifications) -> option.Option(process.Pid) {
+  process.named(notifications.manager) |> option.from_result
+}
+
+pub opaque type NotificationHandle {
+  NotificationHandle(monitor: process.Monitor)
+}
+
+type ManagerMessage {
+  Listen(
+    reply: process.Subject(Result(NotificationHandle, Nil)),
+    receiver: process.Subject(Notification),
+    channel: String,
+  )
+  Unlisten(handle: NotificationHandle, channel: String)
+  ReceivedNotification(notification: ReaderNotification)
+  ListenerDown(monitor: process.Monitor)
+}
+
+type ManagerSubscribingState {
+  ManagerIdle
+  ManagerSubscribing(channel: String, handle: NotificationHandle)
+  ManagerUnsubscribing(channel: String, handle: NotificationHandle)
+}
+
+type ManagerState {
+  NotificationManagerState(
+    inner_state: ManagerSubscribingState,
+    db: pgl.Db,
+    sock: socket.Socket,
+    listeners: dict.Dict(
+      String,
+      List(#(process.Monitor, process.Subject(Notification))),
+    ),
+    // When we're LISTENing or UNLISTENing we still need to receive messages,
+    // we requeue the messages received during the query for later.
+    self_subject: process.Subject(ManagerMessage),
+    reader: process.Subject(ReaderMessage),
+    reader_receiver: process.Subject(ReaderNotification),
+  )
+}
+
+fn start_manager(
+  name: process.Name(ManagerMessage),
+  db: pgl.Db,
+  reader: process.Subject(ReaderMessage),
+) -> actor.StartResult(Nil) {
+  actor.new_with_initialiser(1000, fn(subj) {
+    let reader_receiver = process.new_subject()
+
+    let selector =
+      process.new_selector()
+      |> process.select(subj)
+      |> process.select_map(reader_receiver, fn(reader) {
+        ReceivedNotification(reader)
+      })
+      |> process.select_monitors(fn(down) { ListenerDown(down.monitor) })
+
+    use sock <- result.try(
+      pgl.create_socket(db) |> result.replace_error("unable to create socket"),
+    )
+
+    NotificationManagerState(
+      inner_state: ManagerIdle,
+      db:,
+      sock:,
+      listeners: dict.new(),
+      self_subject: subj,
+      reader:,
+      reader_receiver:,
+    )
+    |> actor.initialised
+    |> actor.selecting(selector)
+    |> Ok
+  })
+  |> actor.named(name)
+  |> actor.on_message(handle_manager_message)
+  |> actor.start
+}
+
+fn handle_manager_message(
+  state: ManagerState,
+  message: ManagerMessage,
+) -> actor.Next(ManagerState, ManagerMessage) {
+  case message {
+    ReceivedNotification(ReaderNotification(notification)) -> {
+      let receivers =
+        dict.get(state.listeners, notification.channel) |> result.unwrap([])
+      list.each(receivers, fn(receiver) {
+        let #(_, receiver) = receiver
+        process.send(receiver, notification)
+      })
+      actor.continue(state)
+    }
+    ReceivedNotification(StoppedReading) ->
+      case state.inner_state {
+        // StoppedReading should only be received, if we issued a sync before.
+        ManagerIdle ->
+          actor.stop_abnormal(
+            "unexpected message ReceivedNotification(StoppedReading)",
+          )
+      }
+    Listen(reply:, receiver:, channel:) ->
+      case state.inner_state {
+        ManagerIdle -> {
+          case
+            result.map(process.subject_owner(receiver), fn(pid) {
+              process.monitor(pid)
+            })
+          {
+            Ok(monitor) -> {
+              let listeners = dict.get(state.listeners, channel)
+
+              case listeners {
+                Error(Nil) ->
+                  case stop_reading(state.sock) {
+                    Ok(Nil) ->
+                      actor.continue(
+                        NotificationManagerState(
+                          ..state,
+                          listeners: dict.insert(state.listeners, channel, [
+                            #(monitor, receiver),
+                          ]),
+                        ),
+                      )
+                    Error(error) ->
+                      actor.stop_abnormal(
+                        "error while writing sync to socket "
+                        <> string.inspect(error),
+                      )
+                  }
+                Ok(listeners) ->
+                  actor.continue(
+                    NotificationManagerState(
+                      ..state,
+                      listeners: dict.insert(state.listeners, channel, [
+                        #(monitor, receiver),
+                        ..listeners
+                      ]),
+                    ),
+                  )
+              }
+            }
+            Error(Nil) -> {
+              process.send(reply, Error(Nil))
+              actor.continue(state)
+            }
+          }
+        }
+        _ -> {
+          process.send(state.self_subject, message)
+          actor.continue(state)
+        }
+      }
+    Unlisten(handle:, channel:) ->
+      case state.inner_state {
+        ManagerIdle -> todo
+        _ -> {
+          process.send(state.self_subject, message)
+          actor.continue(state)
+        }
+      }
+    ListenerDown(monitor:) ->
+      case state.inner_state {
+        ManagerIdle -> todo
+        _ -> {
+          process.send(state.self_subject, message)
+          actor.continue(state)
+        }
+      }
+  }
+}
+
+// The reader process stops reading, when the servers sends the
+// `ReadyForQuery` response due to our `Sync` command.
+fn stop_reading(sock: socket.Socket) -> Result(Nil, internal.InternalError) {
+  socket.send(sock, encode.sync()) |> result.replace(Nil)
+}
+
+fn subscribe(
+  state: ManagerState,
+  channel: String,
+) -> Result(Nil, internal.InternalError) {
+  let connection = conn.new(state.sock, process.self())
+  pgl.extended_query(
+    "LISTEN $1",
+    [pg_value.text(channel)],
+    connection,
+    state.db,
+    // Forwarding any notifications received during the query
+    // to the manager for later processing.
+    option.Some(fn(_proc_id, channel, payload) {
+      process.send(
+        state.self_subject,
+        ReceivedNotification(
+          ReaderNotification(Notification(channel:, payload:)),
+        ),
+      )
+    }),
+  )
+  |> result.replace(Nil)
+}
+
+fn unsubscribe(
+  state: ManagerState,
+  channel: String,
+) -> Result(Nil, internal.InternalError) {
+  let connection = conn.new(state.sock, process.self())
+  pgl.extended_query(
+    "UNLISTEN $1",
+    [pg_value.text(channel)],
+    connection,
+    state.db,
+    // Forwarding any notifications received during the query
+    // to the manager for later processing.
+    option.Some(fn(_proc_id, channel, payload) {
+      process.send(
+        state.self_subject,
+        ReceivedNotification(
+          ReaderNotification(Notification(channel:, payload:)),
+        ),
+      )
+    }),
+  )
+  |> result.replace(Nil)
+}
+
+pub type Notification {
+  Notification(channel: String, payload: String)
+}
+
+type ReaderNotification {
+  ReaderNotification(notification: Notification)
+  StoppedReading
+}
+
+type ReaderMessage {
+  Read(socket: socket.Socket, receiver: process.Subject(ReaderNotification))
+}
+
+fn start_reader(
+  name: process.Name(ReaderMessage),
+) -> actor.StartResult(process.Subject(ReaderMessage)) {
+  actor.new(Nil)
+  |> actor.named(name)
+  |> actor.on_message(handle_reader_message)
+  |> actor.start
+}
+
+fn supervised_reader(
+  name: process.Name(ReaderMessage),
+) -> supervision.ChildSpecification(Nil) {
+  supervision.worker(fn() { start_reader(name) })
+  |> supervision.timeout(1000)
+  |> supervision.restart(supervision.Transient)
+  |> supervision.map_data(fn(_) { Nil })
+}
+
+fn handle_reader_message(
+  _state: Nil,
+  message: ReaderMessage,
+) -> actor.Next(Nil, ReaderMessage) {
+  reader_receive_loop(message.socket, message.receiver)
+}
+
+fn reader_receive_loop(
+  socket: socket.Socket,
+  receiver: process.Subject(ReaderNotification),
+) -> actor.Next(Nil, ReaderMessage) {
+  case protocol.receive_message(socket) {
+    Ok(message) ->
+      case message {
+        // When we want to subscribe to a channel, we don't want
+        // the reader process to be active. By sending a `Sync`
+        // message the postgres server sends this response to the
+        // reader.
+        internal.ReadyForQuery(..) -> {
+          process.send(receiver, StoppedReading)
+          actor.continue(Nil)
+        }
+        internal.NotificationResponse(_proc_id, channel, payload) -> {
+          process.send(
+            receiver,
+            ReaderNotification(Notification(channel:, payload:)),
+          )
+          reader_receive_loop(socket, receiver)
+        }
+        internal.NoticeResponse(..) | internal.ParameterStatus(..) ->
+          reader_receive_loop(socket, receiver)
+        other ->
+          actor.stop_abnormal(
+            "Reader received unexpected message " <> string.inspect(other),
+          )
+      }
+    Error(error) ->
+      actor.stop_abnormal(
+        "Reader failed to read from socket " <> string.inspect(error),
+      )
+  }
+}

--- a/src/pgl/notifications.gleam
+++ b/src/pgl/notifications.gleam
@@ -52,8 +52,8 @@ type ManagerMessage {
 
 type ManagerSubscribingState {
   ManagerIdle
-  ManagerSubscribing(channel: String, handle: NotificationHandle)
-  ManagerUnsubscribing(channel: String, handle: NotificationHandle)
+  ManagerSubscribing(channel: String)
+  ManagerUnsubscribing(channel: String)
 }
 
 type ManagerState {
@@ -144,18 +144,23 @@ fn handle_manager_message(
             Ok(monitor) -> {
               let listeners = dict.get(state.listeners, channel)
 
+              process.send(reply, Ok(NotificationHandle(monitor)))
+
               case listeners {
                 Error(Nil) ->
                   case stop_reading(state.sock) {
-                    Ok(Nil) ->
+                    Ok(Nil) -> {
+
                       actor.continue(
                         NotificationManagerState(
                           ..state,
+                          inner_state: ManagerSubscribing(channel),
                           listeners: dict.insert(state.listeners, channel, [
                             #(monitor, receiver),
                           ]),
                         ),
                       )
+}
                     Error(error) ->
                       actor.stop_abnormal(
                         "error while writing sync to socket "

--- a/src/pgl/notifications.gleam
+++ b/src/pgl/notifications.gleam
@@ -1,3 +1,5 @@
+//// PostgreSQL notification client
+
 import gleam/dict
 import gleam/erlang/process
 import gleam/list
@@ -15,16 +17,26 @@ import pgl/internal/encode
 import pgl/internal/protocol
 import pgl/internal/socket
 
+/// A configured `Notifications` client. Must be started via
+/// `notifications.start` or `notifications.supervised`.
 pub opaque type Notifications {
   Notifications(
     manager: process.Name(ManagerMessage),
     reader: process.Name(ReaderMessage),
+    db: pgl.Db,
+  )
+}
+
+pub fn new(db: pgl.Db) -> Notifications {
+  Notifications(
+    manager: process.new_name("pgl_notifications_manager"),
+    reader: process.new_name("pgl_notifications_reader"),
+    db:,
   )
 }
 
 pub fn start(
   notifications: Notifications,
-  db: pgl.Db,
 ) -> actor.StartResult(static_supervisor.Supervisor) {
   let reader_subject = process.named_subject(notifications.reader)
 
@@ -32,7 +44,7 @@ pub fn start(
   |> static_supervisor.add(supervised_reader(notifications.reader))
   |> static_supervisor.add(supervised_manager(
     notifications.manager,
-    db,
+    notifications.db,
     reader_subject,
   ))
   |> static_supervisor.start
@@ -44,9 +56,8 @@ pub fn manager_pid(notifications: Notifications) -> option.Option(process.Pid) {
 
 pub fn supervised(
   notifications: Notifications,
-  db: pgl.Db,
 ) -> supervision.ChildSpecification(static_supervisor.Supervisor) {
-  supervision.supervisor(fn() { start(notifications, db) })
+  supervision.supervisor(fn() { start(notifications) })
 }
 
 pub fn listen(

--- a/src/pgl/notifications.gleam
+++ b/src/pgl/notifications.gleam
@@ -31,6 +31,7 @@
 // they should crash by either linking to the manager process using `manager_pid`
 // or being in a supervisor which gets restarted when the notification supervisor restarts.
 
+import pg_value
 import gleam/dict
 import gleam/erlang/process
 import gleam/list
@@ -406,8 +407,8 @@ fn subscribe(
 ) -> Result(Nil, internal.InternalError) {
   let connection = conn.new(state.sock, process.self())
   pgl.extended_query(
-    "LISTEN " <> escape_channel(channel),
-    [],
+    "LISTEN \"$1\"",
+    [pg_value.text(channel)],
     connection,
     state.db,
     // Forwarding any notifications received during the query
@@ -430,8 +431,8 @@ fn unsubscribe(
 ) -> Result(Nil, internal.InternalError) {
   let connection = conn.new(state.sock, process.self())
   pgl.extended_query(
-    "UNLISTEN " <> escape_channel(channel),
-    [],
+    "UNLISTEN \"$1\"",
+    [pg_value.text(channel)],
     connection,
     state.db,
     // Forwarding any notifications received during the query

--- a/src/pgl/notifications.gleam
+++ b/src/pgl/notifications.gleam
@@ -46,7 +46,6 @@ type ManagerMessage {
   )
   Unlisten(handle: NotificationHandle)
   ReceivedNotification(notification: ReaderNotification)
-  ListenerDown(monitor: process.Monitor)
 }
 
 type ManagerSubscribingState {
@@ -86,7 +85,9 @@ fn start_manager(
       |> process.select_map(reader_receiver, fn(reader) {
         ReceivedNotification(reader)
       })
-      |> process.select_monitors(fn(down) { ListenerDown(down.monitor) })
+      |> process.select_monitors(fn(down) {
+        Unlisten(NotificationHandle(down.monitor))
+      })
 
     use sock <- result.try(
       pgl.create_socket(db) |> result.replace_error("unable to create socket"),
@@ -189,14 +190,6 @@ fn handle_manager_message(
         }
       }
     Unlisten(handle) ->
-      case state.inner_state {
-        ManagerIdle -> todo
-        _ -> {
-          process.send(state.self_subject, message)
-          actor.continue(state)
-        }
-      }
-    ListenerDown(monitor) ->
       case state.inner_state {
         ManagerIdle -> todo
         _ -> {

--- a/src/pgl_ffi.erl
+++ b/src/pgl_ffi.erl
@@ -6,6 +6,7 @@
   gen_tcp_connect/3,
   gen_tcp_send/2,
   gen_tcp_recv/3,
+  gen_tcp_recv_infinity/2,
   gen_tcp_shutdown/1,
   ssl_connect/3,
   ssl_send/2,
@@ -69,6 +70,10 @@ gen_tcp_shutdown(Socket) ->
 
 gen_tcp_recv(Socket, Size, Timeout) ->
   Resp = gen_tcp:recv(Socket, Size, Timeout),
+  normalise(Resp).
+
+gen_tcp_recv_infinity(Socket, Size) ->
+  Resp = gen_tcp:recv(Socket, Size),
   normalise(Resp).
 
 gen_tcp_send(Socket, Packet) ->

--- a/test/pgl/internal/decode_test.gleam
+++ b/test/pgl/internal/decode_test.gleam
@@ -99,6 +99,21 @@ pub fn decode_parameter_status_test() {
     decode.message(<<"S":utf8>>, <<"TimeZone":utf8, 0, "Etc/UTC":utf8, 0>>)
 }
 
+pub fn decode_notification_response_test() {
+  let assert Ok(internal.NotificationResponse(
+    proc_id: 758,
+    channel: "test_channel",
+    payload: "test_payload",
+  )) =
+    decode.message(<<"A":utf8>>, <<
+      758:size(32),
+      "test_channel":utf8,
+      0,
+      "test_payload":utf8,
+      0,
+    >>)
+}
+
 pub fn decode_authentication_test() {
   [
     #(<<0:int-size(32)>>, internal.AuthenticationOk),

--- a/test/pgl_test.gleam
+++ b/test/pgl_test.gleam
@@ -302,7 +302,7 @@ fn with_db(next: fn(pgl.Db) -> t) {
 
 fn with_db_and_notifications(next: fn(pgl.Db, notifications.Notifications) -> t) {
   let #(db, notifications) = {
-    use <- global_value.create_with_unique_name("pgl_pools")
+    use <- global_value.create_with_unique_name("pgl_pools_notifications")
 
     let db =
       pgl.default
@@ -318,6 +318,8 @@ fn with_db_and_notifications(next: fn(pgl.Db, notifications.Notifications) -> t)
 
     #(db, notifs)
   }
+
+  next(db, notifications)
 }
 
 fn with_conn(db: pgl.Db, next: fn(pgl.Connection) -> t) {

--- a/test/pgl_test.gleam
+++ b/test/pgl_test.gleam
@@ -2,6 +2,7 @@ import gleam/bool
 import gleam/dict
 import gleam/dynamic
 import gleam/dynamic/decode.{type Decoder}
+import gleam/erlang/process
 import gleam/int
 import gleam/list
 import gleam/option.{None, Some}
@@ -16,6 +17,7 @@ import pg_value
 import pg_value/interval
 import pgl
 import pgl/internal
+import pgl/notifications
 
 pub fn main() {
   gleeunit.main()
@@ -296,6 +298,26 @@ fn with_db(next: fn(pgl.Db) -> t) {
   }
 
   next(db)
+}
+
+fn with_db_and_notifications(next: fn(pgl.Db, notifications.Notifications) -> t) {
+  let #(db, notifications) = {
+    use <- global_value.create_with_unique_name("pgl_pools")
+
+    let db =
+      pgl.default
+      |> pgl.username("postgres")
+      |> pgl.password("postgres")
+      |> pgl.new
+
+    let assert Ok(_) = pgl.start(db)
+
+    let notifs = notifications.new(db)
+
+    let assert Ok(_) = notifications.start(notifs)
+
+    #(db, notifs)
+  }
 }
 
 fn with_conn(db: pgl.Db, next: fn(pgl.Connection) -> t) {
@@ -1632,4 +1654,17 @@ pub fn error_to_string_empty_message_test() {
   let result = pgl.error_to_string(err)
 
   assert "(QueryError)" == result
+}
+
+pub fn notifications_test() {
+  use db, notif <- with_db_and_notifications()
+  use conn <- with_conn(db)
+
+  let receiver = process.new_subject()
+  notifications.listen(notif, "pgl_testing", receiver)
+
+  let assert Ok(_) = "NOTIFY pgl_testing, 'test'" |> pgl.sql |> pgl.query(conn)
+
+  let assert Ok(notifications.Notification("pgl_testing", "test")) =
+    process.receive(receiver, 1000)
 }


### PR DESCRIPTION
This PR is currently not ready to merge, as a refactor is required (see below).

This PR adds notification support to pgl (`LISTEN`, `UNLISTEN`).
The design is very loosely based on the `pgo_notifications` module (read top of src/pgl/notifications.gleam for more info).

There are multiple things that still need to be addressed:
- I'm temporarily exporting a few functions from the `pgl` module which the `pgl/notifications` module needs.
  - We'd need to find a way to refactor the code to make `create_socket` and `extended_query` internal functions.
- The changes made to the socket module are very rough and in need of more thought.
- There probably need to be more tests.

Currently I'm looking for feedback over whether the maintainer would be open to this design.
The test does pass, at least on my end.