### PR TITLE
Fix critical SCRAM/SASL/SSL bugs for v2.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## v2.0.1
+
+### Changed
+
+- Default SSL mode is now `SslVerified` (was `SslDisabled`)
+- `from_url` now accepts `prefer` and `allow` as `sslmode` values (mapped to `SslUnverified`)
+- `from_url` without an `sslmode` query parameter now preserves the default SSL setting
+
+### Fixed
+
+- Fixed SSL configuration being silently ignored — the `ssl` setting was never passed to the connection protocol
+- Fixed `from_url` failing when query parameters are present but `sslmode` is not specified
+- Fixed SCRAM nonce generation using only 16 bits of randomness instead of 128 bits
+- Fixed SCRAM client nonce prefix not compared against server nonce
+- Fixed `parse_server_final` crashing with a panic on unexpected SASL payloads instead of returning an error
+- Fixed SASLprep private use character range (`0xF000` corrected to `0xF0000`)
+- Fixed typo in internal SASLprep function name (`plan_text` → `plain_text`)
+
 ## v2.0.0
 
 - Update [`pg_value`](https://hexdocs.pm/pg_value/pg_value.html) to v2.0.0

--- a/gleam.toml
+++ b/gleam.toml
@@ -1,5 +1,5 @@
 name = "pgl"
-version = "2.0.0"
+version = "2.0.1"
 
 description = "A Postgres driver written in gleam"
 licences = ["MIT"]

--- a/src/pgl.gleam
+++ b/src/pgl.gleam
@@ -67,7 +67,7 @@ pub const default = Config(
   password: "",
   database: "",
   connection_parameters: [],
-  ssl: SslDisabled,
+  ssl: SslVerified,
   rows_as_dict: False,
   ip_version: Ipv4,
   pool_size: 5,
@@ -225,20 +225,21 @@ fn apply_database(conf: Config, uri: Uri) -> Result(Config, Nil) {
 
 fn apply_ssl_mode(conf: Config, uri: Uri) -> Result(Config, Nil) {
   case uri.query {
-    None -> Ok(SslDisabled)
+    None -> Ok(conf)
     Some(query) -> {
       use query <- result.try(uri.parse_query(query))
-      use sslmode <- result.try(list.key_find(query, "sslmode"))
-
-      case sslmode {
-        "require" -> Ok(SslUnverified)
-        "verify-ca" | "verify-full" -> Ok(SslVerified)
-        "disable" -> Ok(SslDisabled)
-        _ -> Error(Nil)
+      case list.key_find(query, "sslmode") {
+        Error(Nil) -> Ok(conf)
+        Ok(sslmode) ->
+          case sslmode {
+            "require" | "prefer" | "allow" -> Ok(ssl(conf, SslUnverified))
+            "verify-ca" | "verify-full" -> Ok(ssl(conf, SslVerified))
+            "disable" -> Ok(ssl(conf, SslDisabled))
+            _ -> Error(Nil)
+          }
       }
     }
   }
-  |> result.map(ssl(conf, _))
 }
 
 pub type PglError {
@@ -453,6 +454,11 @@ fn authenticated_connection(
     |> protocol.username(config.username)
     |> protocol.password(config.password)
     |> protocol.database(config.database)
+    |> protocol.ssl(case config.ssl {
+      SslDisabled -> None
+      SslVerified -> Some(True)
+      SslUnverified -> Some(False)
+    })
 
   sockets
   |> socket.connect

--- a/src/pgl/internal/protocol.gleam
+++ b/src/pgl/internal/protocol.gleam
@@ -29,7 +29,7 @@ pub const config = Config(
   password: "",
   application: "",
   connection_parameters: [],
-  ssl: None,
+  ssl: option.Some(True),
 )
 
 pub fn application(conf: Config, application: String) -> Config {

--- a/src/pgl/internal/sasl.gleam
+++ b/src/pgl/internal/sasl.gleam
@@ -19,7 +19,7 @@ pub fn validate(data: BitArray) -> Result(BitArray, Nil) {
       is_private_use_char,
       is_non_char_code_points,
       is_surrogate_code_point,
-      is_inappropriate_for_plan_text_char,
+      is_inappropriate_for_plain_text_char,
       is_inappropriate_for_canonical_representation_char,
       is_change_display_properties_or_deprecated_char,
       is_tagging_char,
@@ -91,7 +91,7 @@ fn is_non_ascii_control_char(char: Int) -> Bool {
 // https://tools.ietf.org/html/rfc3454#appendix-C.3
 fn is_private_use_char(char: Int) -> Bool {
   { 0xE000 <= char && char <= 0xF8FF }
-  || { 0xF000 <= char && char <= 0xFFFFD }
+  || { 0xF0000 <= char && char <= 0xFFFFD }
   || { 0x100000 <= char && char <= 0x10FFFD }
 }
 
@@ -123,7 +123,7 @@ fn is_surrogate_code_point(char: Int) -> Bool {
 }
 
 // https://tools.ietf.org/html/rfc3454#appendix-C.6
-fn is_inappropriate_for_plan_text_char(char: Int) -> Bool {
+fn is_inappropriate_for_plain_text_char(char: Int) -> Bool {
   0xFFF9 <= char && char <= 0xFFFD
 }
 

--- a/src/pgl/internal/scram.gleam
+++ b/src/pgl/internal/scram.gleam
@@ -18,12 +18,8 @@ pub fn client_first(user: BitArray, nonce: BitArray) -> BitArray {
 
 pub fn get_nonce(num_random_bytes: Int) -> BitArray {
   let random = crypto.strong_random_bytes(num_random_bytes)
-  let unique = <<unique_int()>>
-  let nonce_bin = <<
-    num_random_bytes,
-    random:bits-size(num_random_bytes),
-    unique:bits,
-  >>
+  let unique = <<unique_int():int-size(64)>>
+  let nonce_bin = <<random:bits, unique:bits>>
 
   bit_array.base64_encode(nonce_bin, True)
   |> bit_array.from_string
@@ -102,11 +98,15 @@ pub fn parse_server_first(
       use salt <- result.try(bit_array.base64_decode(salt))
       use iterations <- result.try(int.parse(iters))
 
-      let size = bit_array.byte_size(client_nonce)
+      let size = bit_array.bit_size(client_nonce)
 
       case nonce {
-        <<_:bits-size(size), _:bits>> -> {
-          Ok(ServerFirst(nonce:, salt:, iterations:, raw: server_first))
+        <<prefix:bits-size(size), _:bits>> -> {
+          case prefix == client_nonce {
+            True ->
+              Ok(ServerFirst(nonce:, salt:, iterations:, raw: server_first))
+            False -> Error(Nil)
+          }
         }
         _ -> Error(Nil)
       }
@@ -150,7 +150,13 @@ pub fn parse_server_final(
       )
       |> Error
     }
-    _bits -> panic as "Unexpected SASL server final payload"
+    _bits -> {
+      internal.ProtocolError(
+        kind: internal.SaslServerFinal,
+        message: "Unexpected SASL server final payload",
+      )
+      |> Error
+    }
   }
 }
 

--- a/test/pgl/internal/protocol_test.gleam
+++ b/test/pgl/internal/protocol_test.gleam
@@ -51,6 +51,7 @@ pub fn protocol_test() {
     |> protocol.database("gleam_pgl_test")
     |> protocol.username("postgres")
     |> protocol.password("postgres")
+    |> protocol.ssl(option.None)
 
   let sock = connect()
   let assert Ok(sock) = protocol.auth(sock, conf)
@@ -61,7 +62,9 @@ pub fn protocol_test() {
 }
 
 pub fn auth_failure_test() {
-  let conf = protocol.config
+  let conf =
+    protocol.config
+    |> protocol.ssl(option.None)
 
   let sock = connect()
 
@@ -79,6 +82,7 @@ pub fn protocol_bootstrap_test() {
     |> protocol.database("gleam_pgl_test")
     |> protocol.username("postgres")
     |> protocol.password("postgres")
+    |> protocol.ssl(option.None)
 
   let sock = connect()
   let assert Ok(sock) = protocol.auth(sock, conf)
@@ -94,6 +98,7 @@ pub fn ping_test() {
     |> protocol.database("gleam_pgl_test")
     |> protocol.username("postgres")
     |> protocol.password("postgres")
+    |> protocol.ssl(option.None)
 
   let sock = connect()
   let assert Ok(sock) = protocol.auth(sock, conf)

--- a/test/pgl/internal/type_cache_test.gleam
+++ b/test/pgl/internal/type_cache_test.gleam
@@ -1,4 +1,5 @@
 import gleam/list
+import gleam/option
 import gleam/result
 import pgl/internal
 import pgl/internal/protocol
@@ -11,6 +12,7 @@ fn conf() {
   |> protocol.database("gleam_pgl_test")
   |> protocol.username("postgres")
   |> protocol.password("postgres")
+  |> protocol.ssl(option.None)
 }
 
 pub fn load_test() {

--- a/test/pgl_test.gleam
+++ b/test/pgl_test.gleam
@@ -32,7 +32,7 @@ pub fn parse_url_test() {
       database: "gleam_pgl_test",
       username: "postgres",
       password: "supersecretpassword",
-      ssl: pgl.SslDisabled,
+      ssl: pgl.SslVerified,
     )
     == conf
 }
@@ -184,7 +184,7 @@ pub fn default_values_test() {
   assert "" == conf.username
   assert "" == conf.password
   assert "" == conf.database
-  assert pgl.SslDisabled == conf.ssl
+  assert pgl.SslVerified == conf.ssl
   assert pgl.Ipv4 == conf.ip_version
 }
 
@@ -226,6 +226,7 @@ fn dbs() -> Dict(PgVersion, pgl.Db) {
     pgl.default
     |> pgl.username("postgres")
     |> pgl.password("postgres")
+    |> pgl.ssl(pgl.SslDisabled)
 
   let pg_15_conf = base_config |> pgl.port(5415)
   // let pg_15_ssl_conf = pg_15_conf |> pgl.ssl(pgl.SslUnverified)
@@ -271,7 +272,10 @@ fn pg_17_pool_rows_as_maps() -> pgl.Db {
     "postgres://postgres:postgres@127.0.0.1/gleam_pgl_test"
     |> pgl.from_url
 
-  let conf = pgl.rows_as_dict(conf, True)
+  let conf =
+    conf
+    |> pgl.ssl(pgl.SslDisabled)
+    |> pgl.rows_as_dict(True)
 
   let db = pgl.new(conf)
 
@@ -423,6 +427,7 @@ pub fn ipv6_test() {
     |> pgl.password("postgres")
     |> pgl.host("::1")
     |> pgl.ip_version(pgl.Ipv6)
+    |> pgl.ssl(pgl.SslDisabled)
     |> pgl.new
 
   let assert Ok(_) = pgl.start(db)


### PR DESCRIPTION
Fix SSL config being silently ignored — the ssl setting was never passed to the connection protocol, making SSL configuration completely inert. Change default SSL to SslVerified for secure-by-default connections.

Fix apply_ssl_mode failing when URL query params exist without sslmode, and accept prefer/allow as sslmode values (mapped to SslUnverified).

Fix SCRAM nonce generation using only 16 bits of randomness instead of 128 bits, and fix client nonce prefix not being compared against server nonce. Fix parse_server_final panicking on unexpected SASL payloads.

Fix SASLprep private use character range (0xF000 -> 0xF0000) and typo in internal function name (plan_text -> plain_text).