### PR TITLE
More auth methods

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,29 +26,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Enable SSL and create test users
-        run: |
-          openssl req -new -x509 -days 365 -nodes -text \
-            -out server.crt -keyout server.key \
-            -subj "/CN=localhost"
-          CONTAINER=$(docker ps -q --filter "ancestor=postgres:15")
-          docker cp server.crt $CONTAINER:/var/lib/postgresql/server.crt
-          docker cp server.key $CONTAINER:/var/lib/postgresql/server.key
-          docker exec $CONTAINER chown postgres:postgres /var/lib/postgresql/server.crt /var/lib/postgresql/server.key
-          docker exec $CONTAINER chmod 600 /var/lib/postgresql/server.key
-          docker exec $CONTAINER psql -U postgres -c "ALTER SYSTEM SET ssl = 'on';"
-          docker exec $CONTAINER psql -U postgres -c "ALTER SYSTEM SET ssl_cert_file = '/var/lib/postgresql/server.crt';"
-          docker exec $CONTAINER psql -U postgres -c "ALTER SYSTEM SET ssl_key_file = '/var/lib/postgresql/server.key';"
-          docker exec $CONTAINER psql -U postgres -c "SELECT pg_reload_conf();"
-          docker exec $CONTAINER psql -U postgres -c "CREATE USER cleartext_user WITH PASSWORD 'cleartext_pass';"
-          docker exec $CONTAINER psql -U postgres -c "GRANT ALL PRIVILEGES ON DATABASE gleam_pgl_test TO cleartext_user;"
-          docker exec $CONTAINER psql -U postgres -c "CREATE USER trust_user;"
-          docker exec $CONTAINER psql -U postgres -c "GRANT ALL PRIVILEGES ON DATABASE gleam_pgl_test TO trust_user;"
-          docker exec $CONTAINER psql -U postgres -c "SET password_encryption = 'md5'; CREATE USER md5_user WITH PASSWORD 'md5_pass';"
-          docker exec $CONTAINER psql -U postgres -c "GRANT ALL PRIVILEGES ON DATABASE gleam_pgl_test TO md5_user;"
-          docker exec $CONTAINER bash -c "sed -i '/^host.*all.*all.*scram-sha-256/i host all cleartext_user all password' /var/lib/postgresql/data/pg_hba.conf"
-          docker exec $CONTAINER bash -c "sed -i '/^host.*all.*all.*scram-sha-256/i host all trust_user all trust' /var/lib/postgresql/data/pg_hba.conf"
-          docker exec $CONTAINER bash -c "sed -i '/^host.*all.*all.*scram-sha-256/i host all md5_user all md5' /var/lib/postgresql/data/pg_hba.conf"
-          docker exec $CONTAINER psql -U postgres -c "SELECT pg_reload_conf();"
+        run: ./scripts/setup-postgres-ci.sh postgres:15
       - uses: erlef/setup-beam@v1
         with:
           otp-version: "28"
@@ -77,29 +55,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Enable SSL and create test users
-        run: |
-          openssl req -new -x509 -days 365 -nodes -text \
-            -out server.crt -keyout server.key \
-            -subj "/CN=localhost"
-          CONTAINER=$(docker ps -q --filter "ancestor=postgres:16")
-          docker cp server.crt $CONTAINER:/var/lib/postgresql/server.crt
-          docker cp server.key $CONTAINER:/var/lib/postgresql/server.key
-          docker exec $CONTAINER chown postgres:postgres /var/lib/postgresql/server.crt /var/lib/postgresql/server.key
-          docker exec $CONTAINER chmod 600 /var/lib/postgresql/server.key
-          docker exec $CONTAINER psql -U postgres -c "ALTER SYSTEM SET ssl = 'on';"
-          docker exec $CONTAINER psql -U postgres -c "ALTER SYSTEM SET ssl_cert_file = '/var/lib/postgresql/server.crt';"
-          docker exec $CONTAINER psql -U postgres -c "ALTER SYSTEM SET ssl_key_file = '/var/lib/postgresql/server.key';"
-          docker exec $CONTAINER psql -U postgres -c "SELECT pg_reload_conf();"
-          docker exec $CONTAINER psql -U postgres -c "CREATE USER cleartext_user WITH PASSWORD 'cleartext_pass';"
-          docker exec $CONTAINER psql -U postgres -c "GRANT ALL PRIVILEGES ON DATABASE gleam_pgl_test TO cleartext_user;"
-          docker exec $CONTAINER psql -U postgres -c "CREATE USER trust_user;"
-          docker exec $CONTAINER psql -U postgres -c "GRANT ALL PRIVILEGES ON DATABASE gleam_pgl_test TO trust_user;"
-          docker exec $CONTAINER psql -U postgres -c "SET password_encryption = 'md5'; CREATE USER md5_user WITH PASSWORD 'md5_pass';"
-          docker exec $CONTAINER psql -U postgres -c "GRANT ALL PRIVILEGES ON DATABASE gleam_pgl_test TO md5_user;"
-          docker exec $CONTAINER bash -c "sed -i '/^host.*all.*all.*scram-sha-256/i host all cleartext_user all password' /var/lib/postgresql/data/pg_hba.conf"
-          docker exec $CONTAINER bash -c "sed -i '/^host.*all.*all.*scram-sha-256/i host all trust_user all trust' /var/lib/postgresql/data/pg_hba.conf"
-          docker exec $CONTAINER bash -c "sed -i '/^host.*all.*all.*scram-sha-256/i host all md5_user all md5' /var/lib/postgresql/data/pg_hba.conf"
-          docker exec $CONTAINER psql -U postgres -c "SELECT pg_reload_conf();"
+        run: ./scripts/setup-postgres-ci.sh postgres:16
       - uses: erlef/setup-beam@v1
         with:
           otp-version: "28"
@@ -128,29 +84,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Enable SSL and create test users
-        run: |
-          openssl req -new -x509 -days 365 -nodes -text \
-            -out server.crt -keyout server.key \
-            -subj "/CN=localhost"
-          CONTAINER=$(docker ps -q --filter "ancestor=postgres:17")
-          docker cp server.crt $CONTAINER:/var/lib/postgresql/server.crt
-          docker cp server.key $CONTAINER:/var/lib/postgresql/server.key
-          docker exec $CONTAINER chown postgres:postgres /var/lib/postgresql/server.crt /var/lib/postgresql/server.key
-          docker exec $CONTAINER chmod 600 /var/lib/postgresql/server.key
-          docker exec $CONTAINER psql -U postgres -c "ALTER SYSTEM SET ssl = 'on';"
-          docker exec $CONTAINER psql -U postgres -c "ALTER SYSTEM SET ssl_cert_file = '/var/lib/postgresql/server.crt';"
-          docker exec $CONTAINER psql -U postgres -c "ALTER SYSTEM SET ssl_key_file = '/var/lib/postgresql/server.key';"
-          docker exec $CONTAINER psql -U postgres -c "SELECT pg_reload_conf();"
-          docker exec $CONTAINER psql -U postgres -c "CREATE USER cleartext_user WITH PASSWORD 'cleartext_pass';"
-          docker exec $CONTAINER psql -U postgres -c "GRANT ALL PRIVILEGES ON DATABASE gleam_pgl_test TO cleartext_user;"
-          docker exec $CONTAINER psql -U postgres -c "CREATE USER trust_user;"
-          docker exec $CONTAINER psql -U postgres -c "GRANT ALL PRIVILEGES ON DATABASE gleam_pgl_test TO trust_user;"
-          docker exec $CONTAINER psql -U postgres -c "SET password_encryption = 'md5'; CREATE USER md5_user WITH PASSWORD 'md5_pass';"
-          docker exec $CONTAINER psql -U postgres -c "GRANT ALL PRIVILEGES ON DATABASE gleam_pgl_test TO md5_user;"
-          docker exec $CONTAINER bash -c "sed -i '/^host.*all.*all.*scram-sha-256/i host all cleartext_user all password' /var/lib/postgresql/data/pg_hba.conf"
-          docker exec $CONTAINER bash -c "sed -i '/^host.*all.*all.*scram-sha-256/i host all trust_user all trust' /var/lib/postgresql/data/pg_hba.conf"
-          docker exec $CONTAINER bash -c "sed -i '/^host.*all.*all.*scram-sha-256/i host all md5_user all md5' /var/lib/postgresql/data/pg_hba.conf"
-          docker exec $CONTAINER psql -U postgres -c "SELECT pg_reload_conf();"
+        run: ./scripts/setup-postgres-ci.sh postgres:17
       - uses: erlef/setup-beam@v1
         with:
           otp-version: "28"
@@ -180,29 +114,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Enable SSL and create test users
-        run: |
-          openssl req -new -x509 -days 365 -nodes -text \
-            -out server.crt -keyout server.key \
-            -subj "/CN=localhost"
-          CONTAINER=$(docker ps -q --filter "ancestor=postgres:18")
-          docker cp server.crt $CONTAINER:/var/lib/postgresql/server.crt
-          docker cp server.key $CONTAINER:/var/lib/postgresql/server.key
-          docker exec $CONTAINER chown postgres:postgres /var/lib/postgresql/server.crt /var/lib/postgresql/server.key
-          docker exec $CONTAINER chmod 600 /var/lib/postgresql/server.key
-          docker exec $CONTAINER psql -U postgres -c "ALTER SYSTEM SET ssl = 'on';"
-          docker exec $CONTAINER psql -U postgres -c "ALTER SYSTEM SET ssl_cert_file = '/var/lib/postgresql/server.crt';"
-          docker exec $CONTAINER psql -U postgres -c "ALTER SYSTEM SET ssl_key_file = '/var/lib/postgresql/server.key';"
-          docker exec $CONTAINER psql -U postgres -c "SELECT pg_reload_conf();"
-          docker exec $CONTAINER psql -U postgres -c "CREATE USER cleartext_user WITH PASSWORD 'cleartext_pass';"
-          docker exec $CONTAINER psql -U postgres -c "GRANT ALL PRIVILEGES ON DATABASE gleam_pgl_test TO cleartext_user;"
-          docker exec $CONTAINER psql -U postgres -c "CREATE USER trust_user;"
-          docker exec $CONTAINER psql -U postgres -c "GRANT ALL PRIVILEGES ON DATABASE gleam_pgl_test TO trust_user;"
-          docker exec $CONTAINER psql -U postgres -c "SET password_encryption = 'md5'; CREATE USER md5_user WITH PASSWORD 'md5_pass';"
-          docker exec $CONTAINER psql -U postgres -c "GRANT ALL PRIVILEGES ON DATABASE gleam_pgl_test TO md5_user;"
-          docker exec $CONTAINER bash -c "sed -i '/^host.*all.*all.*scram-sha-256/i host all cleartext_user all password' /var/lib/postgresql/data/pg_hba.conf"
-          docker exec $CONTAINER bash -c "sed -i '/^host.*all.*all.*scram-sha-256/i host all trust_user all trust' /var/lib/postgresql/data/pg_hba.conf"
-          docker exec $CONTAINER bash -c "sed -i '/^host.*all.*all.*scram-sha-256/i host all md5_user all md5' /var/lib/postgresql/data/pg_hba.conf"
-          docker exec $CONTAINER psql -U postgres -c "SELECT pg_reload_conf();"
+        run: ./scripts/setup-postgres-ci.sh postgres:18
       - uses: erlef/setup-beam@v1
         with:
           otp-version: "28"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
           - 5432:5432
     steps:
       - uses: actions/checkout@v3
-      - name: Enable SSL on PostgreSQL
+      - name: Enable SSL and create test users
         run: |
           openssl req -new -x509 -days 365 -nodes -text \
             -out server.crt -keyout server.key \
@@ -38,6 +38,16 @@ jobs:
           docker exec $CONTAINER psql -U postgres -c "ALTER SYSTEM SET ssl = 'on';"
           docker exec $CONTAINER psql -U postgres -c "ALTER SYSTEM SET ssl_cert_file = '/var/lib/postgresql/server.crt';"
           docker exec $CONTAINER psql -U postgres -c "ALTER SYSTEM SET ssl_key_file = '/var/lib/postgresql/server.key';"
+          docker exec $CONTAINER psql -U postgres -c "SELECT pg_reload_conf();"
+          docker exec $CONTAINER psql -U postgres -c "CREATE USER cleartext_user WITH PASSWORD 'cleartext_pass';"
+          docker exec $CONTAINER psql -U postgres -c "GRANT ALL PRIVILEGES ON DATABASE gleam_pgl_test TO cleartext_user;"
+          docker exec $CONTAINER psql -U postgres -c "CREATE USER trust_user;"
+          docker exec $CONTAINER psql -U postgres -c "GRANT ALL PRIVILEGES ON DATABASE gleam_pgl_test TO trust_user;"
+          docker exec $CONTAINER psql -U postgres -c "SET password_encryption = 'md5'; CREATE USER md5_user WITH PASSWORD 'md5_pass';"
+          docker exec $CONTAINER psql -U postgres -c "GRANT ALL PRIVILEGES ON DATABASE gleam_pgl_test TO md5_user;"
+          docker exec $CONTAINER bash -c "sed -i '/^host.*all.*all.*scram-sha-256/i host all cleartext_user all password' /var/lib/postgresql/data/pg_hba.conf"
+          docker exec $CONTAINER bash -c "sed -i '/^host.*all.*all.*scram-sha-256/i host all trust_user all trust' /var/lib/postgresql/data/pg_hba.conf"
+          docker exec $CONTAINER bash -c "sed -i '/^host.*all.*all.*scram-sha-256/i host all md5_user all md5' /var/lib/postgresql/data/pg_hba.conf"
           docker exec $CONTAINER psql -U postgres -c "SELECT pg_reload_conf();"
       - uses: erlef/setup-beam@v1
         with:
@@ -66,7 +76,7 @@ jobs:
           - 5432:5432
     steps:
       - uses: actions/checkout@v3
-      - name: Enable SSL on PostgreSQL
+      - name: Enable SSL and create test users
         run: |
           openssl req -new -x509 -days 365 -nodes -text \
             -out server.crt -keyout server.key \
@@ -79,6 +89,16 @@ jobs:
           docker exec $CONTAINER psql -U postgres -c "ALTER SYSTEM SET ssl = 'on';"
           docker exec $CONTAINER psql -U postgres -c "ALTER SYSTEM SET ssl_cert_file = '/var/lib/postgresql/server.crt';"
           docker exec $CONTAINER psql -U postgres -c "ALTER SYSTEM SET ssl_key_file = '/var/lib/postgresql/server.key';"
+          docker exec $CONTAINER psql -U postgres -c "SELECT pg_reload_conf();"
+          docker exec $CONTAINER psql -U postgres -c "CREATE USER cleartext_user WITH PASSWORD 'cleartext_pass';"
+          docker exec $CONTAINER psql -U postgres -c "GRANT ALL PRIVILEGES ON DATABASE gleam_pgl_test TO cleartext_user;"
+          docker exec $CONTAINER psql -U postgres -c "CREATE USER trust_user;"
+          docker exec $CONTAINER psql -U postgres -c "GRANT ALL PRIVILEGES ON DATABASE gleam_pgl_test TO trust_user;"
+          docker exec $CONTAINER psql -U postgres -c "SET password_encryption = 'md5'; CREATE USER md5_user WITH PASSWORD 'md5_pass';"
+          docker exec $CONTAINER psql -U postgres -c "GRANT ALL PRIVILEGES ON DATABASE gleam_pgl_test TO md5_user;"
+          docker exec $CONTAINER bash -c "sed -i '/^host.*all.*all.*scram-sha-256/i host all cleartext_user all password' /var/lib/postgresql/data/pg_hba.conf"
+          docker exec $CONTAINER bash -c "sed -i '/^host.*all.*all.*scram-sha-256/i host all trust_user all trust' /var/lib/postgresql/data/pg_hba.conf"
+          docker exec $CONTAINER bash -c "sed -i '/^host.*all.*all.*scram-sha-256/i host all md5_user all md5' /var/lib/postgresql/data/pg_hba.conf"
           docker exec $CONTAINER psql -U postgres -c "SELECT pg_reload_conf();"
       - uses: erlef/setup-beam@v1
         with:
@@ -107,7 +127,7 @@ jobs:
           - 5432:5432
     steps:
       - uses: actions/checkout@v3
-      - name: Enable SSL on PostgreSQL
+      - name: Enable SSL and create test users
         run: |
           openssl req -new -x509 -days 365 -nodes -text \
             -out server.crt -keyout server.key \
@@ -120,6 +140,16 @@ jobs:
           docker exec $CONTAINER psql -U postgres -c "ALTER SYSTEM SET ssl = 'on';"
           docker exec $CONTAINER psql -U postgres -c "ALTER SYSTEM SET ssl_cert_file = '/var/lib/postgresql/server.crt';"
           docker exec $CONTAINER psql -U postgres -c "ALTER SYSTEM SET ssl_key_file = '/var/lib/postgresql/server.key';"
+          docker exec $CONTAINER psql -U postgres -c "SELECT pg_reload_conf();"
+          docker exec $CONTAINER psql -U postgres -c "CREATE USER cleartext_user WITH PASSWORD 'cleartext_pass';"
+          docker exec $CONTAINER psql -U postgres -c "GRANT ALL PRIVILEGES ON DATABASE gleam_pgl_test TO cleartext_user;"
+          docker exec $CONTAINER psql -U postgres -c "CREATE USER trust_user;"
+          docker exec $CONTAINER psql -U postgres -c "GRANT ALL PRIVILEGES ON DATABASE gleam_pgl_test TO trust_user;"
+          docker exec $CONTAINER psql -U postgres -c "SET password_encryption = 'md5'; CREATE USER md5_user WITH PASSWORD 'md5_pass';"
+          docker exec $CONTAINER psql -U postgres -c "GRANT ALL PRIVILEGES ON DATABASE gleam_pgl_test TO md5_user;"
+          docker exec $CONTAINER bash -c "sed -i '/^host.*all.*all.*scram-sha-256/i host all cleartext_user all password' /var/lib/postgresql/data/pg_hba.conf"
+          docker exec $CONTAINER bash -c "sed -i '/^host.*all.*all.*scram-sha-256/i host all trust_user all trust' /var/lib/postgresql/data/pg_hba.conf"
+          docker exec $CONTAINER bash -c "sed -i '/^host.*all.*all.*scram-sha-256/i host all md5_user all md5' /var/lib/postgresql/data/pg_hba.conf"
           docker exec $CONTAINER psql -U postgres -c "SELECT pg_reload_conf();"
       - uses: erlef/setup-beam@v1
         with:
@@ -149,7 +179,7 @@ jobs:
           - 5432:5432
     steps:
       - uses: actions/checkout@v3
-      - name: Enable SSL on PostgreSQL
+      - name: Enable SSL and create test users
         run: |
           openssl req -new -x509 -days 365 -nodes -text \
             -out server.crt -keyout server.key \
@@ -162,6 +192,16 @@ jobs:
           docker exec $CONTAINER psql -U postgres -c "ALTER SYSTEM SET ssl = 'on';"
           docker exec $CONTAINER psql -U postgres -c "ALTER SYSTEM SET ssl_cert_file = '/var/lib/postgresql/server.crt';"
           docker exec $CONTAINER psql -U postgres -c "ALTER SYSTEM SET ssl_key_file = '/var/lib/postgresql/server.key';"
+          docker exec $CONTAINER psql -U postgres -c "SELECT pg_reload_conf();"
+          docker exec $CONTAINER psql -U postgres -c "CREATE USER cleartext_user WITH PASSWORD 'cleartext_pass';"
+          docker exec $CONTAINER psql -U postgres -c "GRANT ALL PRIVILEGES ON DATABASE gleam_pgl_test TO cleartext_user;"
+          docker exec $CONTAINER psql -U postgres -c "CREATE USER trust_user;"
+          docker exec $CONTAINER psql -U postgres -c "GRANT ALL PRIVILEGES ON DATABASE gleam_pgl_test TO trust_user;"
+          docker exec $CONTAINER psql -U postgres -c "SET password_encryption = 'md5'; CREATE USER md5_user WITH PASSWORD 'md5_pass';"
+          docker exec $CONTAINER psql -U postgres -c "GRANT ALL PRIVILEGES ON DATABASE gleam_pgl_test TO md5_user;"
+          docker exec $CONTAINER bash -c "sed -i '/^host.*all.*all.*scram-sha-256/i host all cleartext_user all password' /var/lib/postgresql/data/pg_hba.conf"
+          docker exec $CONTAINER bash -c "sed -i '/^host.*all.*all.*scram-sha-256/i host all trust_user all trust' /var/lib/postgresql/data/pg_hba.conf"
+          docker exec $CONTAINER bash -c "sed -i '/^host.*all.*all.*scram-sha-256/i host all md5_user all md5' /var/lib/postgresql/data/pg_hba.conf"
           docker exec $CONTAINER psql -U postgres -c "SELECT pg_reload_conf();"
       - uses: erlef/setup-beam@v1
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changed
 
 - `Config` is now opaque
+- Password is now optional
 - Renamed `pgl.default` to `pgl.config`
 - Default SSL mode changed from `SslDisabled` to `SslVerified`
 - Replaced internal `store` module with `rasa`
@@ -17,6 +18,7 @@
 - `ConnectionUnavailable` error variant in `PglError`
 - Socket sends PostgreSQL `Terminate` message before closing connections
 - Added `Enum` and `Json` type tests
+- Added cleartext and MD5 password authentication support
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 - Implementation of PostgreSQL wire protocol
 - SSL support
-- [`SCRAM-SHA-256` Authentication](https://www.postgresql.org/docs/current/sasl-authentication.html#SASL-SCRAM-SHA-256)
+- [`SCRAM-SHA-256`](https://www.postgresql.org/docs/current/sasl-authentication.html#SASL-SCRAM-SHA-256), [Cleartext](https://www.postgresql.org/docs/current/auth-password.html), and [MD5](https://www.postgresql.org/docs/current/auth-password.html) password authentication
 - Connection pooling provided by [`db_pool`](https://github.com/stndrs/db_pool)
 - PostgreSQL data types provided by [`pg_value`](https://github.com/stndrs/pg_value)
 - Transaction support

--- a/scripts/setup-postgres-ci.sh
+++ b/scripts/setup-postgres-ci.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+set -euo pipefail
+
+IMAGE="$1"
+
+# Generate self-signed certificate for SSL
+openssl req -new -x509 -days 365 -nodes -text \
+  -out server.crt -keyout server.key \
+  -subj "/CN=localhost"
+
+CONTAINER=$(docker ps -q --filter "ancestor=$IMAGE")
+
+# Enable SSL
+docker cp server.crt "$CONTAINER":/var/lib/postgresql/server.crt
+docker cp server.key "$CONTAINER":/var/lib/postgresql/server.key
+docker exec "$CONTAINER" chown postgres:postgres /var/lib/postgresql/server.crt /var/lib/postgresql/server.key
+docker exec "$CONTAINER" chmod 600 /var/lib/postgresql/server.key
+docker exec "$CONTAINER" psql -U postgres -c "ALTER SYSTEM SET ssl = 'on';"
+docker exec "$CONTAINER" psql -U postgres -c "ALTER SYSTEM SET ssl_cert_file = '/var/lib/postgresql/server.crt';"
+docker exec "$CONTAINER" psql -U postgres -c "ALTER SYSTEM SET ssl_key_file = '/var/lib/postgresql/server.key';"
+docker exec "$CONTAINER" psql -U postgres -c "SELECT pg_reload_conf();"
+
+# Create test users
+docker exec "$CONTAINER" psql -U postgres -c "CREATE USER cleartext_user WITH PASSWORD 'cleartext_pass';"
+docker exec "$CONTAINER" psql -U postgres -c "GRANT ALL PRIVILEGES ON DATABASE gleam_pgl_test TO cleartext_user;"
+docker exec "$CONTAINER" psql -U postgres -c "CREATE USER trust_user;"
+docker exec "$CONTAINER" psql -U postgres -c "GRANT ALL PRIVILEGES ON DATABASE gleam_pgl_test TO trust_user;"
+docker exec "$CONTAINER" psql -U postgres -c "SET password_encryption = 'md5'; CREATE USER md5_user WITH PASSWORD 'md5_pass';"
+docker exec "$CONTAINER" psql -U postgres -c "GRANT ALL PRIVILEGES ON DATABASE gleam_pgl_test TO md5_user;"
+
+# Configure pg_hba.conf for auth methods
+HBA_FILE=$(docker exec "$CONTAINER" psql -U postgres -tAc "SHOW hba_file;")
+docker exec "$CONTAINER" bash -c "sed -i '/^host.*all.*all.*scram-sha-256/i host all cleartext_user all password' $HBA_FILE"
+docker exec "$CONTAINER" bash -c "sed -i '/^host.*all.*all.*scram-sha-256/i host all trust_user all trust' $HBA_FILE"
+docker exec "$CONTAINER" bash -c "sed -i '/^host.*all.*all.*scram-sha-256/i host all md5_user all md5' $HBA_FILE"
+docker exec "$CONTAINER" psql -U postgres -c "SELECT pg_reload_conf();"

--- a/scripts/start-postgres-ssl.sh
+++ b/scripts/start-postgres-ssl.sh
@@ -19,7 +19,9 @@ CREATE USER cleartext_user WITH PASSWORD 'cleartext_pass';
 GRANT ALL PRIVILEGES ON DATABASE gleam_pgl_test TO cleartext_user;
 CREATE USER trust_user;
 GRANT ALL PRIVILEGES ON DATABASE gleam_pgl_test TO trust_user;
+SET password_encryption = 'md5';
 CREATE USER md5_user WITH PASSWORD 'md5_pass';
+SET password_encryption = 'scram-sha-256';
 GRANT ALL PRIVILEGES ON DATABASE gleam_pgl_test TO md5_user;
 SQL
 

--- a/scripts/start-postgres-ssl.sh
+++ b/scripts/start-postgres-ssl.sh
@@ -12,6 +12,22 @@ chown postgres:postgres /var/lib/postgresql/server.*
 chmod 600 /var/lib/postgresql/server.key
 chmod 644 /var/lib/postgresql/server.crt
 
+# Add init script to create cleartext auth user
+mkdir -p /docker-entrypoint-initdb.d
+cat > /docker-entrypoint-initdb.d/01-cleartext-user.sql <<'SQL'
+CREATE USER cleartext_user WITH PASSWORD 'cleartext_pass';
+GRANT ALL PRIVILEGES ON DATABASE gleam_pgl_test TO cleartext_user;
+SQL
+
+# Add pg_hba entry for cleartext user (will be appended after default entries)
+# We use a custom pg_hba.conf by appending to the data dir after init
+cat > /docker-entrypoint-initdb.d/02-cleartext-hba.sh <<'SCRIPT'
+#!/bin/bash
+# Prepend a password auth rule for cleartext_user before the default scram rules
+sed -i '/^host.*all.*all.*scram-sha-256/i host all cleartext_user all password' "$PGDATA/pg_hba.conf"
+SCRIPT
+chmod +x /docker-entrypoint-initdb.d/02-cleartext-hba.sh
+
 # Start PostgreSQL with SSL enabled
 exec docker-entrypoint.sh postgres \
   -c log_statement=all \

--- a/scripts/start-postgres-ssl.sh
+++ b/scripts/start-postgres-ssl.sh
@@ -14,9 +14,11 @@ chmod 644 /var/lib/postgresql/server.crt
 
 # Add init script to create cleartext auth user
 mkdir -p /docker-entrypoint-initdb.d
-cat > /docker-entrypoint-initdb.d/01-cleartext-user.sql <<'SQL'
+cat > /docker-entrypoint-initdb.d/01-test-users.sql <<'SQL'
 CREATE USER cleartext_user WITH PASSWORD 'cleartext_pass';
 GRANT ALL PRIVILEGES ON DATABASE gleam_pgl_test TO cleartext_user;
+CREATE USER trust_user;
+GRANT ALL PRIVILEGES ON DATABASE gleam_pgl_test TO trust_user;
 SQL
 
 # Add pg_hba entry for cleartext user (will be appended after default entries)
@@ -25,6 +27,7 @@ cat > /docker-entrypoint-initdb.d/02-cleartext-hba.sh <<'SCRIPT'
 #!/bin/bash
 # Prepend a password auth rule for cleartext_user before the default scram rules
 sed -i '/^host.*all.*all.*scram-sha-256/i host all cleartext_user all password' "$PGDATA/pg_hba.conf"
+sed -i '/^host.*all.*all.*scram-sha-256/i host all trust_user all trust' "$PGDATA/pg_hba.conf"
 SCRIPT
 chmod +x /docker-entrypoint-initdb.d/02-cleartext-hba.sh
 

--- a/scripts/start-postgres-ssl.sh
+++ b/scripts/start-postgres-ssl.sh
@@ -19,6 +19,8 @@ CREATE USER cleartext_user WITH PASSWORD 'cleartext_pass';
 GRANT ALL PRIVILEGES ON DATABASE gleam_pgl_test TO cleartext_user;
 CREATE USER trust_user;
 GRANT ALL PRIVILEGES ON DATABASE gleam_pgl_test TO trust_user;
+CREATE USER md5_user WITH PASSWORD 'md5_pass';
+GRANT ALL PRIVILEGES ON DATABASE gleam_pgl_test TO md5_user;
 SQL
 
 # Add pg_hba entry for cleartext user (will be appended after default entries)
@@ -28,6 +30,7 @@ cat > /docker-entrypoint-initdb.d/02-cleartext-hba.sh <<'SCRIPT'
 # Prepend a password auth rule for cleartext_user before the default scram rules
 sed -i '/^host.*all.*all.*scram-sha-256/i host all cleartext_user all password' "$PGDATA/pg_hba.conf"
 sed -i '/^host.*all.*all.*scram-sha-256/i host all trust_user all trust' "$PGDATA/pg_hba.conf"
+sed -i '/^host.*all.*all.*scram-sha-256/i host all md5_user all md5' "$PGDATA/pg_hba.conf"
 SCRIPT
 chmod +x /docker-entrypoint-initdb.d/02-cleartext-hba.sh
 

--- a/src/pgl/internal/protocol.gleam
+++ b/src/pgl/internal/protocol.gleam
@@ -129,6 +129,15 @@ fn auth_flow(
 
   case msg {
     internal.AuthenticationOk -> auth_flow(sock, conf, prev)
+    internal.AuthenticationCleartextPassword -> {
+      use sock <- result.try(
+        conf.password
+        |> encode.password
+        |> socket.send(sock, _),
+      )
+
+      auth_flow(sock, conf, <<>>)
+    }
     internal.AuthenticationSASL(methods:) -> {
       use nonce <- result.try(auth_sasl(sock, methods, conf))
 

--- a/src/pgl/internal/protocol.gleam
+++ b/src/pgl/internal/protocol.gleam
@@ -1,8 +1,10 @@
 import gleam/bit_array
+import gleam/crypto
 import gleam/dict.{type Dict}
 import gleam/dynamic.{type Dynamic}
 import gleam/list
 import gleam/option.{type Option, None, Some}
+import gleam/string
 import gleam/result
 import pgl/internal
 import pgl/internal/decode
@@ -129,6 +131,25 @@ fn auth_flow(
 
   case msg {
     internal.AuthenticationOk -> auth_flow(sock, conf, prev)
+    internal.AuthenticationMD5Password(salt:) -> {
+      case conf.password {
+        option.Some(pass) -> {
+          use sock <- result.try(
+            md5_password(conf.username, pass, salt)
+            |> encode.password
+            |> socket.send(sock, _),
+          )
+
+          auth_flow(sock, conf, <<>>)
+        }
+        option.None ->
+          internal.AuthenticationFailed
+          |> internal.AuthenticationError(
+            "Server requested MD5 authentication but no password was provided",
+          )
+          |> Error
+      }
+    }
     internal.AuthenticationCleartextPassword -> {
       case conf.password {
         option.Some(pass) -> {
@@ -179,6 +200,20 @@ fn auth_flow(
       |> Error
     }
   }
+}
+
+fn md5_password(username: String, password: String, salt: BitArray) -> String {
+  let inner =
+    crypto.hash(crypto.Md5, <<password:utf8, username:utf8>>)
+    |> bit_array.base16_encode
+    |> string.lowercase
+
+  let outer =
+    crypto.hash(crypto.Md5, <<inner:utf8, salt:bits>>)
+    |> bit_array.base16_encode
+    |> string.lowercase
+
+  "md5" <> outer
 }
 
 fn auth_sasl(

--- a/src/pgl/internal/protocol.gleam
+++ b/src/pgl/internal/protocol.gleam
@@ -2,6 +2,7 @@ import gleam/bit_array
 import gleam/crypto
 import gleam/dict.{type Dict}
 import gleam/dynamic.{type Dynamic}
+import gleam/function
 import gleam/list
 import gleam/option.{type Option, None, Some}
 import gleam/result
@@ -131,44 +132,10 @@ fn auth_flow(
 
   case msg {
     internal.AuthenticationOk -> auth_flow(sock, conf, prev)
-    internal.AuthenticationMD5Password(salt:) -> {
-      case conf.password {
-        option.Some(pass) -> {
-          use sock <- result.try(
-            md5_password(conf.username, pass, salt)
-            |> encode.password
-            |> socket.send(sock, _),
-          )
-
-          auth_flow(sock, conf, <<>>)
-        }
-        option.None ->
-          internal.AuthenticationFailed
-          |> internal.AuthenticationError(
-            "Server requested MD5 authentication but no password was provided",
-          )
-          |> Error
-      }
-    }
-    internal.AuthenticationCleartextPassword -> {
-      case conf.password {
-        option.Some(pass) -> {
-          use sock <- result.try(
-            pass
-            |> encode.password
-            |> socket.send(sock, _),
-          )
-
-          auth_flow(sock, conf, <<>>)
-        }
-        option.None ->
-          internal.AuthenticationFailed
-          |> internal.AuthenticationError(
-            "Server requested password authentication but no password was provided",
-          )
-          |> Error
-      }
-    }
+    internal.AuthenticationMD5Password(salt:) ->
+      do_password_auth(conf, md5_password(conf.username, _, salt), "MD5", sock)
+    internal.AuthenticationCleartextPassword ->
+      do_password_auth(conf, function.identity, "password", sock)
     internal.AuthenticationSASL(methods:) -> {
       use nonce <- result.try(auth_sasl(sock, methods, conf))
 
@@ -216,6 +183,31 @@ fn md5_password(username: String, password: String, salt: BitArray) -> String {
   "md5" <> outer
 }
 
+fn do_password_auth(
+  conf: Config,
+  process_password: fn(String) -> String,
+  kind: String,
+  sock: Socket,
+) -> Result(Socket, internal.InternalError) {
+  case conf.password {
+    option.Some(pass) -> {
+      pass
+      |> process_password
+      |> encode.password
+      |> socket.send(sock, _)
+      |> result.try(auth_flow(_, conf, <<>>))
+    }
+    option.None ->
+      internal.AuthenticationFailed
+      |> internal.AuthenticationError(
+        "Server requested "
+        <> kind
+        <> "authentication but no password was provided",
+      )
+      |> Error
+  }
+}
+
 fn auth_sasl(
   sock: Socket,
   methods: List(String),
@@ -261,11 +253,13 @@ fn auth_sasl_continue(
   |> result.try(fn(sf) {
     let user = <<conf.username:utf8>>
     case conf.password {
-      option.None ->
-        Error(internal.AuthenticationError(
-          kind: internal.AuthenticationFailed,
-          message: "Server requested SCRAM authentication but no password was provided",
-        ))
+      option.None -> {
+        internal.AuthenticationFailed
+        |> internal.AuthenticationError(
+          "Server requested SCRAM authentication but no password was provided",
+        )
+        |> Error
+      }
       option.Some(password) -> {
         let pass = <<password:utf8>>
 

--- a/src/pgl/internal/protocol.gleam
+++ b/src/pgl/internal/protocol.gleam
@@ -4,8 +4,8 @@ import gleam/dict.{type Dict}
 import gleam/dynamic.{type Dynamic}
 import gleam/list
 import gleam/option.{type Option, None, Some}
-import gleam/string
 import gleam/result
+import gleam/string
 import pgl/internal
 import pgl/internal/decode
 import pgl/internal/encode

--- a/src/pgl/internal/protocol.gleam
+++ b/src/pgl/internal/protocol.gleam
@@ -16,7 +16,7 @@ pub type Config {
   Config(
     database: String,
     username: String,
-    password: String,
+    password: Option(String),
     application: String,
     connection_parameters: List(#(String, String)),
     ssl: Option(Bool),
@@ -26,7 +26,7 @@ pub type Config {
 pub const config = Config(
   database: "",
   username: "",
-  password: "",
+  password: None,
   application: "",
   connection_parameters: [],
   ssl: Some(True),
@@ -48,7 +48,7 @@ pub fn username(conf: Config, username: String) -> Config {
 }
 
 pub fn password(conf: Config, password: String) -> Config {
-  Config(..conf, password:)
+  Config(..conf, password: Some(password))
 }
 
 pub fn database(conf: Config, database: String) -> Config {
@@ -130,13 +130,23 @@ fn auth_flow(
   case msg {
     internal.AuthenticationOk -> auth_flow(sock, conf, prev)
     internal.AuthenticationCleartextPassword -> {
-      use sock <- result.try(
-        conf.password
-        |> encode.password
-        |> socket.send(sock, _),
-      )
+      case conf.password {
+        option.Some(pass) -> {
+          use sock <- result.try(
+            pass
+            |> encode.password
+            |> socket.send(sock, _),
+          )
 
-      auth_flow(sock, conf, <<>>)
+          auth_flow(sock, conf, <<>>)
+        }
+        option.None ->
+          internal.AuthenticationFailed
+          |> internal.AuthenticationError(
+            "Server requested password authentication but no password was provided",
+          )
+          |> Error
+      }
     }
     internal.AuthenticationSASL(methods:) -> {
       use nonce <- result.try(auth_sasl(sock, methods, conf))
@@ -215,19 +225,28 @@ fn auth_sasl_continue(
   scram.parse_server_first(server_first, client_nonce)
   |> result.try(fn(sf) {
     let user = <<conf.username:utf8>>
-    let pass = <<conf.password:utf8>>
+    case conf.password {
+      option.None ->
+        Error(internal.AuthenticationError(
+          kind: internal.AuthenticationFailed,
+          message: "Server requested SCRAM authentication but no password was provided",
+        ))
+      option.Some(password) -> {
+        let pass = <<password:utf8>>
 
-    use #(client_final, server_signature) <- result.try(scram.client_final(
-      sf,
-      client_nonce,
-      user,
-      pass,
-    ))
+        use #(client_final, server_signature) <- result.try(scram.client_final(
+          sf,
+          client_nonce,
+          user,
+          pass,
+        ))
 
-    let encoded_client_final = encode.scram_response(client_final)
+        let encoded_client_final = encode.scram_response(client_final)
 
-    socket.send(sock, encoded_client_final)
-    |> result.replace(server_signature)
+        socket.send(sock, encoded_client_final)
+        |> result.replace(server_signature)
+      }
+    }
   })
 }
 

--- a/test/pgl/internal/protocol_test.gleam
+++ b/test/pgl/internal/protocol_test.gleam
@@ -1,4 +1,4 @@
-import gleam/option.{Some}
+import gleam/option.{None, Some}
 import pgl/internal
 import pgl/internal/encode
 import pgl/internal/protocol
@@ -19,7 +19,7 @@ pub fn config_test() {
   assert "pgl" == conf.application
   assert "gleam_pgl_test" == conf.database
   assert "postgres" == conf.username
-  assert "postgres" == conf.password
+  assert option.Some("postgres") == conf.password
   assert [#("timezone", "MDT")] == conf.connection_parameters
   assert option.Some(True) == conf.ssl
 }
@@ -85,6 +85,23 @@ pub fn auth_cleartext_password_test() {
   let assert Ok([[option.Some(<<"1":utf8>>)]]) =
     encode.query("SELECT 1")
     |> protocol.simple(sock)
+}
+
+pub fn auth_trust_test() {
+  let conf =
+    protocol.config
+    |> protocol.database("gleam_pgl_test")
+    |> protocol.username("trust_user")
+    |> protocol.ssl(Some(False))
+
+  let sock = connect()
+  let assert Ok(sock) = protocol.auth(sock, conf)
+
+  let assert Ok([[option.Some(<<"1":utf8>>)]]) =
+    encode.query("SELECT 1")
+    |> protocol.simple(sock)
+
+  assert None == conf.password
 }
 
 fn connect() -> Socket {

--- a/test/pgl/internal/protocol_test.gleam
+++ b/test/pgl/internal/protocol_test.gleam
@@ -87,6 +87,22 @@ pub fn auth_cleartext_password_test() {
     |> protocol.simple(sock)
 }
 
+pub fn auth_md5_password_test() {
+  let conf =
+    protocol.config
+    |> protocol.database("gleam_pgl_test")
+    |> protocol.username("md5_user")
+    |> protocol.password("md5_pass")
+    |> protocol.ssl(Some(False))
+
+  let sock = connect()
+  let assert Ok(sock) = protocol.auth(sock, conf)
+
+  let assert Ok([[option.Some(<<"1":utf8>>)]]) =
+    encode.query("SELECT 1")
+    |> protocol.simple(sock)
+}
+
 pub fn auth_trust_test() {
   let conf =
     protocol.config

--- a/test/pgl/internal/protocol_test.gleam
+++ b/test/pgl/internal/protocol_test.gleam
@@ -71,6 +71,22 @@ pub fn protocol_bootstrap_test() {
     |> protocol.simple(sock)
 }
 
+pub fn auth_cleartext_password_test() {
+  let conf =
+    protocol.config
+    |> protocol.database("gleam_pgl_test")
+    |> protocol.username("cleartext_user")
+    |> protocol.password("cleartext_pass")
+    |> protocol.ssl(Some(False))
+
+  let sock = connect()
+  let assert Ok(sock) = protocol.auth(sock, conf)
+
+  let assert Ok([[option.Some(<<"1":utf8>>)]]) =
+    encode.query("SELECT 1")
+    |> protocol.simple(sock)
+}
+
 fn connect() -> Socket {
   let sockets =
     socket.new()

--- a/test/pgl_test.gleam
+++ b/test/pgl_test.gleam
@@ -2047,7 +2047,7 @@ pub fn md5_auth_query_test() {
     |> pgl.database("gleam_pgl_test")
     |> pgl.username("md5_user")
     |> pgl.password("md5_pass")
-    |> pgl.ssl(pgl.SslDisabled)
+    |> pgl.ssl(pgl.SslUnverified)
     |> pgl.new
 
   let assert Ok(_) = pgl.start(db)

--- a/test/pgl_test.gleam
+++ b/test/pgl_test.gleam
@@ -2038,3 +2038,67 @@ pub fn json_string_constant_test() {
 
   assert #("value", 42) == parsed
 }
+
+pub fn md5_auth_query_test() {
+  let db =
+    pgl.config
+    |> pgl.host("127.0.0.1")
+    |> pgl.port(5432)
+    |> pgl.database("gleam_pgl_test")
+    |> pgl.username("md5_user")
+    |> pgl.password("md5_pass")
+    |> pgl.ssl(pgl.SslDisabled)
+    |> pgl.new
+
+  let assert Ok(_) = pgl.start(db)
+
+  use conn <- with_conn(db)
+
+  let assert Ok(result) =
+    pgl.sql("SELECT 1 AS val, 'md5_auth' AS auth_type")
+    |> pgl.query(conn)
+
+  assert 1 == result.count
+
+  let row_decoder = {
+    use val <- decode.field(0, decode.int)
+    use auth_type <- decode.field(1, decode.string)
+    decode.success(#(val, auth_type))
+  }
+
+  let assert Ok([#(1, "md5_auth")]) =
+    result.rows
+    |> list.try_map(decode.run(_, row_decoder))
+}
+
+pub fn cleartext_auth_query_test() {
+  let db =
+    pgl.config
+    |> pgl.host("127.0.0.1")
+    |> pgl.port(5432)
+    |> pgl.database("gleam_pgl_test")
+    |> pgl.username("cleartext_user")
+    |> pgl.password("cleartext_pass")
+    |> pgl.ssl(pgl.SslDisabled)
+    |> pgl.new
+
+  let assert Ok(_) = pgl.start(db)
+
+  use conn <- with_conn(db)
+
+  let assert Ok(result) =
+    pgl.sql("SELECT 1 AS val, 'cleartext_auth' AS auth_type")
+    |> pgl.query(conn)
+
+  assert 1 == result.count
+
+  let row_decoder = {
+    use val <- decode.field(0, decode.int)
+    use auth_type <- decode.field(1, decode.string)
+    decode.success(#(val, auth_type))
+  }
+
+  let assert Ok([#(1, "cleartext_auth")]) =
+    result.rows
+    |> list.try_map(decode.run(_, row_decoder))
+}


### PR DESCRIPTION
This PR adds support for [cleartext and MD5 password authentication](https://www.postgresql.org/docs/current/auth-password.html).