### PR TITLE
Pipeline error bug fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.0.1
+
+- Fixed calls to `pgl.batch` timing out when one of the queries causes the server to issue an `ErrorResponse`.
+
 ## v3.0.0
 
 ### Changed

--- a/gleam.toml
+++ b/gleam.toml
@@ -1,5 +1,5 @@
 name = "pgl"
-version = "3.0.0"
+version = "3.0.1"
 
 description = "A Postgres driver written in Gleam"
 licences = ["MIT"]

--- a/src/pgl/internal/protocol.gleam
+++ b/src/pgl/internal/protocol.gleam
@@ -614,16 +614,23 @@ fn error_response_cleanup(
   ready: Int,
   sock: Socket,
 ) -> Result(a, internal.InternalError) {
-  let err = case needs_sync {
-    False -> flush(err, sock)
-    True ->
-      encode.sync()
-      |> socket.send(sock, _)
-      |> result.try(fn(_) { flush(err, sock) })
+  let #(err, syncs) = case needs_sync {
+    False -> #(flush(err, sock), syncs)
+    True -> {
+      let err =
+        encode.sync()
+        |> socket.send(sock, _)
+        |> result.try(fn(_) { flush(err, sock) })
+      #(err, syncs + 1)
+    }
   }
 
+  // Each flush consumes one ReadyForQuery, so increment ready
+  // before comparing to avoid an extra flush that would block forever.
+  let ready = ready + 1
+
   case syncs > ready {
-    True -> error_response_cleanup(err, False, syncs, ready + 1, sock)
+    True -> error_response_cleanup(err, False, syncs, ready, sock)
     False -> err
   }
 }

--- a/test/pgl_test.gleam
+++ b/test/pgl_test.gleam
@@ -394,6 +394,44 @@ pub fn pipeline_multiple_different_queries_test() {
     |> pgl.batch(conn)
 }
 
+pub fn pipeline_batch_partial_failure_test() {
+  use db <- with_db()
+  use conn <- with_conn(db)
+  use conn <- with_users_table(conn)
+
+  let insert1 =
+    insert_into_users([
+      "900, 'William', false, ARRAY['Will'], '1990-02-09', now()",
+    ])
+
+  let insert2 =
+    insert_into_users([
+      "901, 'William', false, ARRAY['Will'], '1990-02-09', now()",
+    ])
+
+  let insert3 =
+    insert_into_users([
+      "902, 'William', false, ARRAY['Will'], '1990-02-09', now()",
+    ])
+
+  let assert Error(pgl.PostgresError(code:, name:, message:, fields:)) =
+    [
+      pgl.Query(insert1, []),
+      pgl.Query(insert2, []),
+      pgl.Query(insert3, []),
+      pgl.Query(insert1, []),
+    ]
+    |> pgl.batch(conn)
+
+  let assert "23505" = code
+  let assert "unique_violation" = name
+  let assert "duplicate key value violates unique constraint \"users_pkey\"" =
+    message
+
+  let assert Ok("users_pkey") = dict.get(fields, pgl.Constraint)
+  let assert Ok("Key (id)=(900) already exists.") = dict.get(fields, pgl.Detail)
+}
+
 pub fn pipeline_dependent_queries_test() {
   let drop1 = "DROP TABLE IF EXISTS new_users;"
   let drop2 = "DROP TABLE IF EXISTS posts;"


### PR DESCRIPTION
Fixes a bug caused by `error_response_cleanup` in `protocol.gleam` when a pipeline contains a query that results in the server issuing an `ErrorResponse`. The issue was that flush consumes a `ReadyForQuery` message but the ready counter wasn't incremented accordingly, causing the recursive call to attempt an extra flush that blocks forever.

Whether `needs_sync` is `True` or `False` we call `flush`. Only in the `True` case to we call `sync` first and then `flush`. Both cases call `flush` so the `ready` counter must be incremented by 1. Only in the `True` case do we also need to increment the `sync` counter by 1.

Added a test where the pipeline fails on one of the queries and returns the expected error.